### PR TITLE
bugfix: VelociraptorCatalogue renamed Catalogue

### DIFF
--- a/swiftgalaxy/halo_finders.py
+++ b/swiftgalaxy/halo_finders.py
@@ -176,7 +176,7 @@ class Velociraptor(_HaloFinder):
         centre_type: str = "minpot",  # _gas _star mbp minpot
         velociraptor_suffix: str = "",
     ) -> None:
-        from velociraptor.catalogue.catalogue import VelociraptorCatalogue
+        from velociraptor.catalogue.catalogue import Catalogue
 
         if velociraptor_filebase is not None and velociraptor_files is not None:
             raise ValueError(
@@ -198,7 +198,7 @@ class Velociraptor(_HaloFinder):
         else:
             self.halo_index: int = halo_index
         self.centre_type: str = centre_type
-        self._catalogue: Optional[VelociraptorCatalogue] = None
+        self._catalogue: Optional[Catalogue] = None
         self._particles: Optional[None] = None
         super().__init__(extra_mask=extra_mask)
         # currently velociraptor_python works with a halo index, not halo_id


### PR DESCRIPTION
Velociraptor package decided to rename VelociraptorCatalogue to Catalogue. Update swiftgalaxy to match. Velociraptor hasn't updated the name everywhere, tests should pass once https://github.com/SWIFTSIM/velociraptor-python/pull/98 is merged and a new release pushed to pypi.