### PR TITLE
Handle iteration over 0 or 1 target objects

### DIFF
--- a/swiftgalaxy/iterator.py
+++ b/swiftgalaxy/iterator.py
@@ -232,18 +232,25 @@ class SWIFTGalaxies:
                 "optimize_iteration must be one of 'dense', 'sparse' or 'auto'."
             )
 
-        # before evaluating optimized solutions, if we have 0 targets short-circuit
         if self.halo_catalogue._index_attr is not None:
-            target_list = getattr(self.halo_catalogue, self.halo_catalogue._index_attr)
-            if len(target_list) == 0:
-                self._solution = _IterationSolution(
-                    regions=np.array([]),
-                    region_target_indices=[np.array([])],
-                    cost=-1,
-                )
-                return
-            if len(target_list) == 1:
-                optimize_iteration = "sparse"  # 1 target is sparse by definition
+            num_targets = len(
+                getattr(self.halo_catalogue, self.halo_catalogue._index_attr)
+            )
+        else:
+            num_targets = len(self.halo_catalogue._region_centre)
+            print(num_targets)
+        # before evaluating optimized solutions:
+        if num_targets == 0:
+            # if we have 0 targets short-circuit
+            self._solution = _IterationSolution(
+                regions=np.array([]),
+                region_target_indices=[np.array([])],
+                cost=-1,
+            )
+            return
+        if num_targets == 1:
+            # if we have 1 target best strategy is sparse
+            optimize_iteration = "sparse"
 
         if optimize_iteration in ("dense", "auto"):
             self._eval_dense_optimized_solution()

--- a/swiftgalaxy/iterator.py
+++ b/swiftgalaxy/iterator.py
@@ -13,8 +13,18 @@ from .reader import SWIFTGalaxy
 from .halo_catalogues import _HaloCatalogue
 from warnings import warn
 
-from typing import Optional, Set, Any, List, Callable, Dict, Tuple, Generator
+from typing import Optional, Set, Any, List, Callable, Dict, Tuple, Generator, TypedDict
 from swiftsimio.masks import SWIFTMask
+
+
+class _IterationSolution(TypedDict):
+    """
+    Type hints for dicts containing a proposed SWIFTGalaxies iteration strategy.
+    """
+
+    regions: np.ndarray
+    region_target_indices: list[np.ndarray]
+    cost: int
 
 
 class SWIFTGalaxies:
@@ -221,6 +231,20 @@ class SWIFTGalaxies:
             raise ValueError(
                 "optimize_iteration must be one of 'dense', 'sparse' or 'auto'."
             )
+
+        # before evaluating optimized solutions, if we have 0 targets short-circuit
+        if self.halo_catalogue._index_attr is not None:
+            target_list = getattr(self.halo_catalogue, self.halo_catalogue._index_attr)
+            if len(target_list) == 0:
+                self._solution = _IterationSolution(
+                    regions=np.array([]),
+                    region_target_indices=[np.array([])],
+                    cost=-1,
+                )
+                return
+            if len(target_list) == 1:
+                optimize_iteration = "sparse"  # 1 target is sparse by definition
+
         if optimize_iteration in ("dense", "auto"):
             self._eval_dense_optimized_solution()
         if optimize_iteration in ("sparse", "auto"):
@@ -243,6 +267,7 @@ class SWIFTGalaxies:
             self._solution = self._dense_optimized_solution
         elif optimize_iteration == "sparse":
             self._solution = self._sparse_optimized_solution
+        return
 
     @property
     def iteration_order(self) -> np.ndarray:
@@ -277,7 +302,7 @@ class SWIFTGalaxies:
         interest in each of the regions; ``"cost"`` containing the cost (in top-level cell
         read operations) of this iteration scheme.
         """
-        target_centres = self.halo_catalogue._region_centre
+        target_centres = np.atleast_2d(self.halo_catalogue._region_centre)
         if self.halo_catalogue._user_spatial_offsets is not None:
             target_regions = self.halo_catalogue._user_spatial_offsets[np.newaxis, ...]
         else:
@@ -324,7 +349,7 @@ class SWIFTGalaxies:
         # region_target_indices contains an array of indices into the targets array
         # for each region
         # cost is the integer number of cells that will be read during this iteration
-        self._sparse_optimized_solution = dict(
+        self._sparse_optimized_solution = _IterationSolution(
             regions=unique_regions,
             region_target_indices=np.split(
                 np.arange(inv.size)[sorter],
@@ -358,7 +383,7 @@ class SWIFTGalaxies:
         scheme. The actual cost depends on the size of the grid regions and whether none,
         one or both of the grids are aligned with the top-level cell grid.
         """
-        target_centres = self.halo_catalogue._region_centre
+        target_centres = np.atleast_2d(self.halo_catalogue._region_centre)
         if self.halo_catalogue._user_spatial_offsets is not None:
             target_sizes = np.diff(self.halo_catalogue._user_spatial_offsets).T
         else:
@@ -478,7 +503,7 @@ class SWIFTGalaxies:
         # cost_max is an integer number of cells that will be read during this iteration
         # in the worst case (assuming both grids are mis-aligned with the cell grid)
         sorter = np.argsort(inv)
-        self._dense_optimized_solution = dict(
+        self._dense_optimized_solution = _IterationSolution(
             regions=unique_regions,
             region_target_indices=np.split(
                 np.arange(inv.size)[sorter],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -639,3 +639,201 @@ def hf_multi(request):
                 cosmo_factor=cosmo_factor(a**1, 1.0),
             ),
         )
+
+
+@pytest.fixture(scope="function", params=hfs)
+def hf_multi_forwards_and_backwards(request):
+    if request.param in {"caesar_halo", "caesar_galaxy"}:
+        create_toycaesar()
+
+        yield Caesar(
+            caesar_file=toycaesar_filename,
+            group_type=request.param.split("_")[-1],
+            group_index=[0, 1],
+        ), Caesar(
+            caesar_file=toycaesar_filename,
+            group_type=request.param.split("_")[-1],
+            group_index=[1, 0],
+        )
+
+        remove_toycaesar()
+    elif request.param == "soap":
+        create_toysoap(create_virtual_snapshot=os.path.isfile(toysnap_filename))
+
+        yield SOAP(
+            soap_file=toysoap_filename,
+            soap_index=[0, 1],
+        ), SOAP(
+            soap_file=toysoap_filename,
+            soap_index=[1, 0],
+        )
+
+        remove_toysoap()
+    elif request.param == "vr":
+        create_toyvr()
+
+        yield Velociraptor(
+            velociraptor_filebase=toyvr_filebase, halo_index=[0, 1]
+        ), Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=[1, 0])
+
+        remove_toyvr()
+    elif request.param == "sa":
+        yield Standalone(
+            extra_mask=None,
+            centre=cosmo_array(
+                [
+                    [centre_1 + 0.001, centre_1 + 0.001, centre_1 + 0.001],
+                    [centre_2 + 0.001, centre_2 + 0.001, centre_2 + 0.001],
+                ],
+                u.Mpc,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**1, 1.0),
+            ),
+            velocity_centre=cosmo_array(
+                [
+                    [vcentre_1 + 1.0, vcentre_1 + 1.0, vcentre_1 + 1.0],
+                    [vcentre_2 + 1.0, vcentre_2 + 1.0, vcentre_2 + 1.0],
+                ],
+                u.km / u.s,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**0, 1.0),
+            ),
+            spatial_offsets=cosmo_array(
+                [[-1, 1], [-1, 1], [-1, 1]],
+                u.Mpc,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**1, 1.0),
+            ),
+        ), Standalone(
+            extra_mask=None,
+            centre=cosmo_array(
+                [
+                    [centre_2 + 0.001, centre_2 + 0.001, centre_2 + 0.001],
+                    [centre_1 + 0.001, centre_1 + 0.001, centre_1 + 0.001],
+                ],
+                u.Mpc,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**1, 1.0),
+            ),
+            velocity_centre=cosmo_array(
+                [
+                    [vcentre_2 + 1.0, vcentre_2 + 1.0, vcentre_2 + 1.0],
+                    [vcentre_1 + 1.0, vcentre_1 + 1.0, vcentre_1 + 1.0],
+                ],
+                u.km / u.s,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**0, 1.0),
+            ),
+            spatial_offsets=cosmo_array(
+                [[-1, 1], [-1, 1], [-1, 1]],
+                u.Mpc,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**1, 1.0),
+            ),
+        )
+
+
+@pytest.fixture(scope="function", params=hfs)
+def hf_multi_onetarget(request):
+    if request.param in {"caesar_halo", "caesar_galaxy"}:
+        create_toycaesar()
+
+        yield Caesar(
+            caesar_file=toycaesar_filename,
+            group_type=request.param.split("_")[-1],
+            group_index=[1],
+        )
+
+        remove_toycaesar()
+    elif request.param == "soap":
+        create_toysoap(create_virtual_snapshot=os.path.isfile(toysnap_filename))
+
+        yield SOAP(
+            soap_file=toysoap_filename,
+            soap_index=[1],
+        )
+
+        remove_toysoap()
+    elif request.param == "vr":
+        create_toyvr()
+
+        yield Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=[1])
+
+        remove_toyvr()
+    elif request.param == "sa":
+        yield Standalone(
+            extra_mask=None,
+            centre=cosmo_array(
+                [
+                    [centre_2 + 0.001, centre_2 + 0.001, centre_2 + 0.001],
+                ],
+                u.Mpc,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**1, 1.0),
+            ),
+            velocity_centre=cosmo_array(
+                [
+                    [vcentre_2 + 1.0, vcentre_2 + 1.0, vcentre_2 + 1.0],
+                ],
+                u.km / u.s,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**0, 1.0),
+            ),
+            spatial_offsets=cosmo_array(
+                [[-1, 1], [-1, 1], [-1, 1]],
+                u.Mpc,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**1, 1.0),
+            ),
+        )
+
+
+@pytest.fixture(scope="function", params=hfs)
+def hf_multi_zerotarget(request):
+    if request.param in {"caesar_halo", "caesar_galaxy"}:
+        create_toycaesar()
+
+        yield Caesar(
+            caesar_file=toycaesar_filename,
+            group_type=request.param.split("_")[-1],
+            group_index=[],
+        )
+
+        remove_toycaesar()
+    elif request.param == "soap":
+        create_toysoap(create_virtual_snapshot=os.path.isfile(toysnap_filename))
+
+        yield SOAP(
+            soap_file=toysoap_filename,
+            soap_index=[],
+        )
+
+        remove_toysoap()
+    elif request.param == "vr":
+        create_toyvr()
+
+        yield Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=[])
+
+        remove_toyvr()
+    elif request.param == "sa":
+        yield Standalone(
+            extra_mask=None,
+            centre=cosmo_array(
+                [],
+                u.Mpc,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**1, 1.0),
+            ),
+            velocity_centre=cosmo_array(
+                [],
+                u.km / u.s,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**0, 1.0),
+            ),
+            spatial_offsets=cosmo_array(
+                [[-1, 1], [-1, 1], [-1, 1]],
+                u.Mpc,
+                comoving=True,
+                cosmo_factor=cosmo_factor(a**1, 1.0),
+            ),
+        )

--- a/tests/test_halo_catalogues.py
+++ b/tests/test_halo_catalogues.py
@@ -392,9 +392,11 @@ class TestHaloCataloguesMulti:
             # this is Standalone, nothing to do
             return
         # strip the leading underscore with [1:] to access the property
-        assert getattr(hf_multi, hf_multi._index_attr[1:]) == [0, 1]
+        indices_without_mask = getattr(hf_multi, hf_multi._index_attr[1:])
+        assert indices_without_mask == [0, 1]
         hf_multi._mask_multi_galaxy(0)
-        assert getattr(hf_multi, hf_multi._index_attr[1:]) == 0
+        indices_with_mask = getattr(hf_multi, hf_multi._index_attr[1:])
+        assert indices_with_mask == 0
 
     def test_masked_catalogue_matches(self, hf_multi):
         mask_index = 0
@@ -424,6 +426,7 @@ class TestHaloCataloguesMulti:
         hf = hf_multi.__class__(**init_args)
         hf_multi._mask_multi_galaxy(mask_index)
         if hf_multi.__class__ == SOAP:
+            assert hf.soap_index == hf_multi.soap_index
             assert (
                 hf.bound_subhalo.enclose_radius == hf_multi.bound_subhalo.enclose_radius
             )

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -540,3 +540,55 @@ class TestSWIFTGalaxies:
             remove_toyvr()
         elif "caesar" in hf_type:
             remove_toycaesar()
+
+
+class TestSWIFTGalaxiesWithSOAP:
+
+    def test_zero_targets(self, toysnap_withfof, toysoap_with_virtual_snapshot):
+        """
+        Make sure we don't crash with zero targets. Instead iterate over zero elements.
+        """
+        target_list = []
+        sgs = SWIFTGalaxies(
+            toysoap_virtual_snapshot_filename,
+            SOAP(soap_file=toysoap_filename, soap_index=target_list),
+            preload={  # just to keep warnings quiet
+                "gas.particle_ids",
+                "dark_matter.particle_ids",
+                "stars.particle_ids",
+                "black_holes.particle_ids",
+            },
+        )
+        for sg in sgs:  # should not crash by iterating
+            # but should not reach this:
+            raise RuntimeError("Supposed to iterate over 0 elements!")
+
+        def f(sg):
+            # _index_attr has leading underscore, access through property with [1:]
+            return getattr(sg.halo_catalogue, sg.halo_catalogue._index_attr[1:])
+
+        assert sgs.map(f) == target_list
+
+    def test_one_target(self, toysnap_withfof, toysoap_with_virtual_snapshot):
+        """
+        Make sure that we don't crash with a single target. Instead iterate over it.
+        """
+        target_list = [1]
+        sgs = SWIFTGalaxies(
+            toysoap_virtual_snapshot_filename,
+            SOAP(soap_file=toysoap_filename, soap_index=target_list),
+            preload={  # just to keep warnings quiet
+                "gas.particle_ids",
+                "dark_matter.particle_ids",
+                "stars.particle_ids",
+                "black_holes.particle_ids",
+            },
+        )
+        for sg in sgs:  # should iterate over the one target
+            assert sg.halo_catalogue.soap_index == target_list[0]
+
+        def f(sg):
+            # _index_attr has leading underscore, access through property with [1:]
+            return getattr(sg.halo_catalogue, sg.halo_catalogue._index_attr[1:])
+
+        assert sgs.map(f) == target_list

--- a/tests/toysnap.py
+++ b/tests/toysnap.py
@@ -164,13 +164,13 @@ class ToyHF(_HaloCatalogue):
             u.Mpc,
             comoving=True,
             cosmo_factor=cosmo_factor(a**1, 1.0),
-        )
+        )[(self.index,)]
 
     @property
     def _region_aperture(self):
         return cosmo_array(
             [0.5, 0.5], u.Mpc, comoving=True, cosmo_factor=cosmo_factor(a**1, 1.0)
-        )
+        )[(self.index,)]
 
     def _get_preload_fields(self, server):
         return set()


### PR DESCRIPTION
`SWIFTGalaxies` would fail with various errors in cases where a list of targets of length 0 or 1 was passed to the `HaloCatalogue` used to set it up. Users wouldn't normally attempt this, but it can easily come up in automated target selection scripts. These cases are now handled properly: iteration will proceed over a of length 0 or 1 in these cases.

Thanks to Will Roper for pointing this out.