### PR TITLE
Bugfix: Copy named column data when deep copying

### DIFF
--- a/swiftgalaxy/iterator.py
+++ b/swiftgalaxy/iterator.py
@@ -239,7 +239,6 @@ class SWIFTGalaxies:
             )
         else:
             num_targets = len(self.halo_catalogue._region_centre)
-            print(num_targets)
         # before evaluating optimized solutions:
         if num_targets == 0:
             # if we have 0 targets short-circuit

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -1910,7 +1910,9 @@ class SWIFTGalaxy(SWIFTDataset):
                         )
                         if data is not None:
                             setattr(
-                                new_named_columns_helper, f"_{named_column}", data[mask]
+                                new_named_columns_helper._named_column_dataset,
+                                f"_{named_column}",
+                                data[mask],
                             )
                 else:
                     data = getattr(

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,0 +1,32 @@
+from copy import deepcopy
+import unyt as u
+from unyt.testing import assert_allclose_units
+
+abstol_m = 1e2 * u.solMass
+reltol_m = 1.0e-4
+abstol_nd = 1.0e-4
+reltol_nd = 1.0e-4
+
+
+class TestCopySWIFTGalaxy:
+    def test_deepcopy_sg(self, sg):
+        """
+        Test that datasets get copied on deep copy.
+        """
+        # lazy load a dataset and a named column
+        sg.gas.masses
+        sg.gas.hydrogen_ionization_fractions.neutral
+        sg_copy = deepcopy(sg)
+        # check private attribute to not trigger lazy loading
+        assert_allclose_units(
+            sg.gas.masses,
+            sg_copy.gas._particle_dataset._masses,
+            rtol=reltol_m,
+            atol=abstol_m,
+        )
+        assert_allclose_units(
+            sg.gas.hydrogen_ionization_fractions.neutral,
+            sg_copy.gas.hydrogen_ionization_fractions._named_column_dataset._neutral,
+            rtol=reltol_nd,
+            atol=abstol_nd,
+        )


### PR DESCRIPTION
Closes #28 

There was a bug: named column data was attached to helper instead of internal dataset in v2.0.0. This PR adds tests for this and a fix.