### PR TITLE
Use cell bboxes in test data

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -19,6 +19,6 @@
     "codeRepository": [
         "https://github.com/SWIFTSIM/swiftgalaxy",
     ],
-    "version": "2.0.2",
+    "version": "2.0.3",
     "license": "https://spdx.org/licenses/GPL-3.0-only.html",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swiftgalaxy"
-version="2.0.2"
+version="2.0.3"
 authors = [
     { name="Kyle Oman", email="kyle.a.oman@durham.ac.uk" },
 ]

--- a/swiftgalaxy/__version__.py
+++ b/swiftgalaxy/__version__.py
@@ -1,1 +1,3 @@
-__version__ = "2.0.2"
+import importlib.metadata
+
+__version__ = importlib.metadata.version("swiftgalaxy")

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -216,14 +216,19 @@ class _HaloCatalogue(ABC):
             The spatial mask to select particles in the region of interest.
         """
         sm = mask(snapshot_filename, spatial_only=True)
-        region = self._user_spatial_offsets
-        if region is not None:
-            for ax in range(3):
-                region[ax] = (
-                    [self.centre[ax] + region[ax][0], self.centre[ax] + region[ax][1]]
-                    if region[ax] is not None
+        user_region = self._user_spatial_offsets
+        if user_region is not None:
+            region = [
+                (
+                    [
+                        self.centre[ax] + user_region[ax][0],
+                        self.centre[ax] + user_region[ax][1],
+                    ]
+                    if user_region[ax] is not None
                     else None
                 )
+                for ax in range(3)
+            ]
             sm.constrain_spatial(region)
         return sm
 
@@ -1657,12 +1662,16 @@ class Caesar(_HaloCatalogue):
         if "total_rmax" in cat.radii.keys():
             # spatial extent information is present, define the mask
             pos = cosmo_array(
-                cat.pos.to(u.kpc),  # maybe comoving, ensure physical
+                cat.pos.to_value(u.kpc),  # maybe comoving, ensure physical
+                u.kpc,
                 comoving=False,
                 cosmo_factor=cosmo_factor(a**1, self._caesar.simulation.scale_factor),
             ).to_comoving()
             rmax = cosmo_array(
-                cat.radii["total_rmax"].to(u.kpc),  # maybe comoving, ensure physical
+                cat.radii["total_rmax"].to_value(
+                    u.kpc
+                ),  # maybe comoving, ensure physical
+                u.kpc,
                 comoving=False,
                 cosmo_factor=cosmo_factor(a**1, self._caesar.simulation.scale_factor),
             ).to_comoving()

--- a/tests/toysnap.py
+++ b/tests/toysnap.py
@@ -500,6 +500,32 @@ def create_toysnap(
         fg.create_dataset("PartType1", data=np.array([0, 0], dtype=int))
         fg.create_dataset("PartType4", data=np.array([0, 0], dtype=int))
         fg.create_dataset("PartType5", data=np.array([0, 0], dtype=int))
+        bbming = g.create_group("MinPositions")
+        bbming.create_dataset(
+            "PartType0", data=np.array([[0, 0, 0], [5, 0, 0]], dtype=int)
+        )
+        bbming.create_dataset(
+            "PartType1", data=np.array([[0, 0, 0], [5, 0, 0]], dtype=int)
+        )
+        bbming.create_dataset(
+            "PartType4", data=np.array([[0, 0, 0], [5, 0, 0]], dtype=int)
+        )
+        bbming.create_dataset(
+            "PartType5", data=np.array([[0, 0, 0], [5, 0, 0]], dtype=int)
+        )
+        bbmaxg = g.create_group("MaxPositions")
+        bbmaxg.create_dataset(
+            "PartType0", data=np.array([[5, 10, 10], [10, 10, 10]], dtype=int)
+        )
+        bbmaxg.create_dataset(
+            "PartType1", data=np.array([[5, 10, 10], [10, 10, 10]], dtype=int)
+        )
+        bbmaxg.create_dataset(
+            "PartType4", data=np.array([[5, 10, 10], [10, 10, 10]], dtype=int)
+        )
+        bbmaxg.create_dataset(
+            "PartType5", data=np.array([[5, 10, 10], [10, 10, 10]], dtype=int)
+        )
         mdg = g.create_group("Meta-data")
         mdg.attrs["dimension"] = np.array([[2, 1, 1]], dtype=int)
         mdg.attrs["nr_cells"] = np.array([2], dtype=int)


### PR DESCRIPTION
Swiftsimio now supports using the cell bounding box metadata in newer snapshots. Added this feature to the test data (otherwise we get 700+ warnings, for a start) and fixed a bug in caesar user defined regions that this happens to reveal. 