### PR TITLE
Add missing items in catalogue tab completion, and test

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -19,6 +19,6 @@
     "codeRepository": [
         "https://github.com/SWIFTSIM/swiftgalaxy",
     ],
-    "version": "2.1.2",
+    "version": "2.1.3",
     "license": "https://spdx.org/licenses/GPL-3.0-only.html",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swiftgalaxy"
-version="2.1.2"
+version="2.1.3"
 authors = [
     { name="Kyle Oman", email="kyle.a.oman@durham.ac.uk" },
 ]

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -363,8 +363,8 @@ class _HaloCatalogue(ABC):
         out : list
             The list of catalogue attribute names.
         """
-        # use getattr to default to None, e.g. for Standalone
-        return dir(getattr(self, "_catalogue", None))
+        # use getattr to default to empty list, e.g. for Standalone
+        return list(object.__dir__(self)) + list(dir(getattr(self, "_catalogue", [])))
 
     def __getattr__(self, attr: str) -> Any:
         """
@@ -902,22 +902,6 @@ class SOAP(_HaloCatalogue):
             The string representation of the catalogue.
         """
         return self._catalogue.__repr__()
-
-    def __dir__(self) -> list[str]:
-        """
-        Supply a list of attributes of the halo catalogue.
-
-        The regular ``dir`` behaviour doesn't index the names of catalogue attributes
-        because they're attached to the internally maintained ``_catalogue`` attribute,
-        so we custimize the ``__dir__`` method to list the attribute names. They will
-        then appear in tab completion, for example.
-
-        Returns
-        -------
-        out : list
-            The list of catalogue attribute names.
-        """
-        return list(self._catalogue.metadata.present_group_names)
 
 
 class Velociraptor(_HaloCatalogue):

--- a/tests/test_halo_catalogues.py
+++ b/tests/test_halo_catalogues.py
@@ -581,9 +581,12 @@ class TestVelociraptor:
         """
         Check that we add catalogue properties to the namespace directory.
 
-        Just check a couple, don't need to be exhaustive.
+        Just check a couple, don't need to be exhaustive. Also make sure we list the
+        attriubtes of the wrapper class itself.
         """
         for prop in ("energies", "metallicity", "temperature"):
+            assert prop in dir(vr)
+        for prop in ("centre_type", "extra_mask"):
             assert prop in dir(vr)
 
     def test_required_args(self):
@@ -783,10 +786,13 @@ class TestCaesar:
         """
         Check that we add catalogue properties to the namespace directory.
 
-        Just check a couple, don't need to be exhaustive.
+        Just check a couple, don't need to be exhaustive. Also make sure we list the
+        attriubtes of the wrapper class itself.
         """
         # picked these to be common between halo and galaxy catalogues:
         for prop in ("glist", "pos", "radii"):
+            assert prop in dir(caesar)
+        for prop in ("centre_type", "extra_mask"):
             assert prop in dir(caesar)
 
     def test_required_args(self, caesar):
@@ -1056,6 +1062,15 @@ class TestStandalone:
         """
         assert sa._mask_index is None
 
+    def test_dir_for_tab_completion(self, sa):
+        """
+        Check that we can use tab completion.
+
+        Make sure we list the attriubtes of the wrapper class itself.
+        """
+        for prop in ("centre", "extra_mask"):
+            assert prop in dir(sa)
+
 
 class TestSOAP:
     def test_load(self, soap):
@@ -1179,7 +1194,8 @@ class TestSOAP:
         """
         Check that we add catalogue properties to the namespace directory.
 
-        Just check a couple, don't need to be exhaustive.
+        Just check a couple, don't need to be exhaustive. Also make sure we list the
+        attriubtes of the wrapper class itself.
         """
         for prop in (
             "exclusive_sphere_100kpc",
@@ -1187,6 +1203,11 @@ class TestSOAP:
             "spherical_overdensity_bn98",
         ):
             assert prop in dir(soap)
+        assert "halo_centre" in dir(soap.input_halos)
+        for prop in ("centre_type", "extra_mask"):
+            assert prop in dir(soap)
+        # make sure that we didn't trigger lazy loading of everything
+        assert soap.input_halos._halo_centre is None
 
     def test_required_args(self):
         """

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,25 @@
+import importlib.metadata
+import swiftgalaxy
+
+
+class TestVersion:
+    """
+    Check that version numbering is consistent.
+    """
+
+    def test_code_version(self):
+        """
+        Check that code version matches pyproject.toml version.
+        """
+        assert importlib.metadata.version("swiftgalaxy") == swiftgalaxy.__version__
+
+    def test_codemeta_version(self):
+        """
+        Check that the version in codemeta.json matches pyproject.toml version.
+        """
+        with open("codemeta.json") as f:
+            codemeta_content = f.read()
+        assert (
+            f'"version": "{importlib.metadata.version("swiftgalaxy")}",'
+            in codemeta_content
+        )


### PR DESCRIPTION
The tab completion listing (from our implementation of `__dir__`) failed to list attributes of the helper classes for halo catalogues, instead only listing attributes of the wrapped catalogues. This is now fixed, with some better test coverage added.

Closes #41