### PR TITLE
Use temporary directories for test data

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -65,13 +65,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest pytest-xdist
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f optional_requirements.txt ]; then pip install -r optional_requirements.txt; fi
         pip install -e .
     - name: Test with pytest
       run: |
-        pytest
+        pytest -n 2
 
   tests-and-coverage:
     needs: lint
@@ -97,13 +97,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-cov
+        pip install flake8 pytest pytest-cov pytest-xdist
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f optional_requirements.txt ]; then pip install -r optional_requirements.txt; fi
         pip install -e .
     - name: Test with pytest including coverage report
       run: |
-        pytest --cov --cov-branch --cov-report=xml
+        pytest -n 2 --cov --cov-branch --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       env:

--- a/swiftgalaxy/demo_data.py
+++ b/swiftgalaxy/demo_data.py
@@ -212,12 +212,19 @@ class _WebExamples(object):
 
     def remove(self) -> None:
         """
-        Remove all downloaded example files.
+        Remove all downloaded example files. Also removes the example data directory, if
+        it is empty after the files have been removed.
         """
         for example_dict in self.available_examples.values():
             filenames = example_dict["files"]
             for filename in filenames:
                 (self._demo_data_dir / filename).unlink(missing_ok=True)
+        try:
+            self._demo_data_dir.rmdir()
+        except OSError:
+            # it wasn't empty, doesn't exist or is not a directory by the time we got here
+            pass
+        return
 
 
 web_examples = _WebExamples()
@@ -324,7 +331,8 @@ class _GeneratedExamples(object):
 
     def remove(self) -> None:
         """
-        Remove all generated example files.
+        Remove all generated example files. Also removes the example data directory, if
+        it is empty after the files have been removed.
         """
         _remove_toysnap(snapfile=self._demo_data_dir / _toysnap_filename.name)
         _remove_toyvr(filebase=self._demo_data_dir / _toyvr_filebase.name)
@@ -335,6 +343,11 @@ class _GeneratedExamples(object):
             virtual_snapshot_filename=self._demo_data_dir
             / _toysoap_virtual_snapshot_filename.name,
         )
+        try:
+            self._demo_data_dir.rmdir()
+        except OSError:
+            # it wasn't empty, doesn't exist or is not a directory by the time we got here
+            pass
         return
 
 

--- a/swiftgalaxy/demo_data.py
+++ b/swiftgalaxy/demo_data.py
@@ -1147,8 +1147,8 @@ def _create_toyvr(filebase: Union[str, Path] = _toyvr_filebase) -> None:
         The base name for catalogue files (several files ``base.properties``,
         ``base.catalog_groups``, etc. will be created).
     """
-    if not Path(f"{_toyvr_filebase}.properties").is_file():
-        with h5py.File(f"{_toyvr_filebase}.properties", "w") as f:
+    if not Path(f"{filebase}.properties").is_file():
+        with h5py.File(f"{filebase}.properties", "w") as f:
             f.create_group("SimulationInfo")
             f["SimulationInfo"].attrs["ScaleFactor"] = 1.0
             f["SimulationInfo"].attrs["Cosmological_Sim"] = 1
@@ -1320,8 +1320,8 @@ def _create_toyvr(filebase: Union[str, Path] = _toyvr_filebase) -> None:
             f["numSubStruct"].attrs["Dimension_Mass"] = 0.0
             f["numSubStruct"].attrs["Dimension_Time"] = 0.0
             f["numSubStruct"].attrs["Dimension_Velocity"] = 0.0
-    if not Path(f"{_toyvr_filebase}.catalog_groups").is_file():
-        with h5py.File(f"{_toyvr_filebase}.catalog_groups", "w") as f:
+    if not Path(f"{filebase}.catalog_groups").is_file():
+        with h5py.File(f"{filebase}.catalog_groups", "w") as f:
             f.create_dataset("File_id", data=np.array([0, 0], dtype=int))
             f.create_dataset(
                 "Group_Size",
@@ -1348,8 +1348,8 @@ def _create_toyvr(filebase: Union[str, Path] = _toyvr_filebase) -> None:
             )
             f.create_dataset("Parent_halo_ID", data=np.array([-1, -1], dtype=int))
             f.create_dataset("Total_num_of_groups", data=np.array([2], dtype=int))
-    if not Path(f"{_toyvr_filebase}.catalog_particles").is_file():
-        with h5py.File(f"{_toyvr_filebase}.catalog_particles", "w") as f:
+    if not Path(f"{filebase}.catalog_particles").is_file():
+        with h5py.File(f"{filebase}.catalog_particles", "w") as f:
             f.create_dataset("File_id", data=np.array([0], dtype=int))
             f.create_dataset("Num_of_files", data=np.array([1], dtype=int))
             f.create_dataset(
@@ -1425,8 +1425,8 @@ def _create_toyvr(filebase: Union[str, Path] = _toyvr_filebase) -> None:
                     dtype=int,
                 ),
             )
-    if not Path(f"{_toyvr_filebase}.catalog_particles.unbound").is_file():
-        with h5py.File(f"{_toyvr_filebase}.catalog_particles.unbound", "w") as f:
+    if not Path(f"{filebase}.catalog_particles.unbound").is_file():
+        with h5py.File(f"{filebase}.catalog_particles.unbound", "w") as f:
             f.create_dataset("File_id", data=np.array([0], dtype=int))
             f.create_dataset("Num_of_files", data=np.array([1], dtype=int))
             f.create_dataset(
@@ -1452,8 +1452,8 @@ def _create_toyvr(filebase: Union[str, Path] = _toyvr_filebase) -> None:
                 "Total_num_of_particles_in_all_groups",
                 data=np.array([_n_g_b + _n_dm_b], dtype=int),
             )
-    if not Path(f"{_toyvr_filebase}.catalog_parttypes").is_file():
-        with h5py.File(f"{_toyvr_filebase}.catalog_parttypes", "w") as f:
+    if not Path(f"{filebase}.catalog_parttypes").is_file():
+        with h5py.File(f"{filebase}.catalog_parttypes", "w") as f:
             f.create_dataset("File_id", data=np.array([0], dtype=int))
             f.create_dataset("Num_of_files", data=np.array([1], dtype=int))
             f.create_dataset(
@@ -1497,8 +1497,8 @@ def _create_toyvr(filebase: Union[str, Path] = _toyvr_filebase) -> None:
                     dtype=int,
                 ),
             )
-    if not Path(f"{_toyvr_filebase}.catalog_parttypes.unbound").is_file():
-        with h5py.File(f"{_toyvr_filebase}.catalog_parttypes.unbound", "w") as f:
+    if not Path(f"{filebase}.catalog_parttypes.unbound").is_file():
+        with h5py.File(f"{filebase}.catalog_parttypes.unbound", "w") as f:
             f.create_dataset("File_id", data=np.array([0], dtype=int))
             f.create_dataset("Num_of_files", data=np.array([1], dtype=int))
             f.create_dataset(
@@ -1531,12 +1531,12 @@ def _remove_toyvr(filebase: Union[str, Path] = _toyvr_filebase) -> None:
         ``base.catalog_groups``, etc. will be removed).
     """
     files_to_remove = (
-        f"{_toyvr_filebase}.properties",
-        f"{_toyvr_filebase}.catalog_groups",
-        f"{_toyvr_filebase}.catalog_particles",
-        f"{_toyvr_filebase}.catalog_particles.unbound",
-        f"{_toyvr_filebase}.catalog_parttypes",
-        f"{_toyvr_filebase}.catalog_parttypes.unbound",
+        f"{filebase}.properties",
+        f"{filebase}.catalog_groups",
+        f"{filebase}.catalog_particles",
+        f"{filebase}.catalog_particles.unbound",
+        f"{filebase}.catalog_parttypes",
+        f"{filebase}.catalog_parttypes.unbound",
     )
     for file_to_remove in files_to_remove:
         Path(file_to_remove).unlink(missing_ok=True)
@@ -2918,6 +2918,7 @@ def _create_toysoap(
 
     if create_membership:
         if not Path(f"{membership_filebase}.0.hdf5").is_file():
+            Path(membership_filebase).parent.mkdir(exist_ok=True)
             with h5py.File(f"{membership_filebase}.0.hdf5", "w") as f:
                 fof_ids = {
                     0: np.concatenate(
@@ -3113,6 +3114,7 @@ def _remove_toysoap(
         Filename for virtual snapshot file.
     """
     Path(filename).unlink(missing_ok=True)
-    for path in Path().glob(f"{membership_filebase}.*.hdf5"):
+    membership_path = Path(membership_filebase)
+    for path in membership_path.parent.glob(f"{membership_path.name}.*.hdf5"):
         path.unlink(missing_ok=True)
     Path(virtual_snapshot_filename).unlink(missing_ok=True)

--- a/swiftgalaxy/iterator.py
+++ b/swiftgalaxy/iterator.py
@@ -29,7 +29,7 @@ class _IterationSolution(TypedDict):
     cost: int
 
 
-class SWIFTGalaxies:
+class SWIFTGalaxies(object):
     """
     Facilitates efficiently iterating over many objects of interest from a simulation.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,8 @@ from swiftgalaxy.demo_data import (
     _centre_2,
     _vcentre_1,
     _vcentre_2,
+    generated_examples,
+    web_examples,
 )
 
 hfs = ("vr", "caesar_halo", "caesar_galaxy", "sa", "soap")
@@ -1100,3 +1102,15 @@ def lm():
 
     lm = LazyMask(mask_function=mf)
     yield lm
+
+
+@pytest.fixture(scope="function")
+def generated_examples_tmpdir(tmp_path_factory):
+    generated_examples._demo_data_dir = tmp_path_factory.mktemp("demo_data")
+    return generated_examples
+
+
+@pytest.fixture(scope="function")
+def web_examples_tmpdir(tmp_path_factory):
+    web_examples._demo_data_dir = tmp_path_factory.mktemp("demo_data")
+    return web_examples

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from swiftgalaxy.demo_data import (
     ToyHF,
     _toysnap_filename,
     _toysoap_filename,
+    _toysoap_membership_filebase,
     _toysoap_virtual_snapshot_filename,
     _toyvr_filebase,
     _toycaesar_filename,
@@ -40,52 +41,86 @@ hfs = ("vr", "caesar_halo", "caesar_galaxy", "sa", "soap")
 
 
 @pytest.fixture(scope="function")
-def toysnap():
-    _create_toysnap()
+def toysnap(tmp_path_factory):
+    toysnap_filename = (
+        tmp_path_factory.mktemp(_toysnap_filename.parent) / _toysnap_filename.name
+    )
+    _create_toysnap(snapfile=toysnap_filename)
 
-    yield
+    yield {"toysnap_filename": toysnap_filename}
 
-    _remove_toysnap()
-
-
-@pytest.fixture(scope="function")
-def toysnap_withfof():
-    _create_toysnap(withfof=True)
-
-    yield
-
-    _remove_toysnap()
+    _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function")
-def toysoap_with_virtual_snapshot():
-    _create_toysoap(create_virtual_snapshot=True)
+def toysnap_withfof(tmp_path_factory):
+    toysnap_filename = (
+        tmp_path_factory.mktemp(_toysnap_filename.parent) / _toysnap_filename.name
+    )
+    _create_toysnap(snapfile=toysnap_filename, withfof=True)
 
-    yield
+    yield {"toysnap_filename": toysnap_filename}
 
-    _remove_toysoap()
+    _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function")
-def sg(request):
-    _create_toysnap()
+def toysoap_with_virtual_snapshot(tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysoap_filename.parent)
+    toysoap_filename = tp / _toysoap_filename.name
+    membership_filebase = tp / _toysoap_membership_filebase.name
+    toysnap_filename = tp / _toysnap_filename.name
+    toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
+    _create_toysnap(toysnap_filename, withfof=True)
+    _create_toysoap(
+        filename=toysoap_filename,
+        membership_filebase=membership_filebase,
+        create_virtual_snapshot=True,
+        create_virtual_snapshot_from=toysnap_filename,
+        virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+    )
+
+    yield {
+        "toysoap_filename": toysoap_filename,
+        "membership_filebase": membership_filebase,
+        "toysnap_filename": toysnap_filename,
+        "toysoap_virtual_snapshot_filename": toysoap_virtual_snapshot_filename,
+    }
+
+    _remove_toysoap(
+        filename=toysoap_filename,
+        membership_filebase=membership_filebase,
+        virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+    )
+    _remove_toysnap(snapfile=toysnap_filename)
+
+
+@pytest.fixture(scope="function")
+def sg(request, tmp_path_factory):
+    toysnap_filename = (
+        tmp_path_factory.mktemp(_toysnap_filename.parent) / _toysnap_filename.name
+    )
+    _create_toysnap(snapfile=toysnap_filename)
 
     yield SWIFTGalaxy(
-        _toysnap_filename,
-        ToyHF(),
+        toysnap_filename,
+        ToyHF(snapfile=toysnap_filename),
         transforms_like_coordinates={"coordinates", "extra_coordinates"},
         transforms_like_velocities={"velocities", "extra_velocities"},
     )
 
-    _remove_toysnap()
+    _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function")
-def sgs(request):
-    _create_toysnap()
+def sgs(request, tmp_path_factory):
+    toysnap_filename = (
+        tmp_path_factory.mktemp(_toysnap_filename.parent) / _toysnap_filename.name
+    )
+    _create_toysnap(snapfile=toysnap_filename)
     yield SWIFTGalaxies(
-        _toysnap_filename,
-        ToyHF(index=[0, 1]),
+        toysnap_filename,
+        ToyHF(snapfile=toysnap_filename, index=[0, 1]),
         transforms_like_coordinates={"coordinates", "extra_coordinates"},
         transforms_like_velocities={"velocities", "extra_velocities"},
         preload={  # just to keep warnings quiet
@@ -95,12 +130,13 @@ def sgs(request):
             "black_holes.particle_ids",
         },
     )
-    _remove_toysnap()
+    _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function")
-def sg_custom_names():
-    toysnap_custom_names_filename = "toysnap_custom_names.hdf5"
+def sg_custom_names(tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_custom_names_filename = tp / "toysnap_custom_names.hdf5"
     alt_coord_name, alt_vel_name, alt_id_name = "my_coords", "my_vels", "my_ids"
 
     _create_toysnap(
@@ -124,48 +160,77 @@ def sg_custom_names():
 
 
 @pytest.fixture(scope="function")
-def sg_autorecentre_off():
-    _create_toysnap()
+def sg_autorecentre_off(tmp_path_factory):
+    toysnap_filename = (
+        tmp_path_factory.mktemp(_toysnap_filename.parent) / _toysnap_filename.name
+    )
+    _create_toysnap(snapfile=toysnap_filename)
 
     yield SWIFTGalaxy(
-        _toysnap_filename,
-        ToyHF(snapfile=_toysnap_filename),
+        toysnap_filename,
+        ToyHF(snapfile=toysnap_filename),
         transforms_like_coordinates={"coordinates", "extra_coordinates"},
         transforms_like_velocities={"velocities", "extra_velocities"},
         auto_recentre=False,
     )
 
-    _remove_toysnap(snapfile=_toysnap_filename)
+    _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function")
-def sg_soap():
-    _create_toysnap(withfof=True)
-    _create_toysoap(create_virtual_snapshot=True)
+def sg_soap(tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    toysoap_filename = tp / _toysoap_filename.name
+    membership_filebase = tp / _toysoap_membership_filebase.name
+    toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
+    _create_toysnap(snapfile=toysnap_filename, withfof=True)
+    _create_toysoap(
+        filename=toysoap_filename,
+        membership_filebase=membership_filebase,
+        create_virtual_snapshot=True,
+        create_virtual_snapshot_from=toysnap_filename,
+        virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+    )
 
     yield SWIFTGalaxy(
-        _toysoap_virtual_snapshot_filename,
+        toysoap_virtual_snapshot_filename,
         SOAP(
-            soap_file=_toysoap_filename,
+            soap_file=toysoap_filename,
             soap_index=0,
         ),
         transforms_like_coordinates={"coordinates", "extra_coordinates"},
         transforms_like_velocities={"velocities", "extra_velocities"},
     )
 
-    _remove_toysnap()
-    _remove_toysoap()
+    _remove_toysnap(snapfile=toysnap_filename)
+    _remove_toysoap(
+        filename=toysoap_filename,
+        membership_filebase=membership_filebase,
+        virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+    )
 
 
 @pytest.fixture(scope="function")
-def sgs_soap():
-    _create_toysnap(withfof=True)
-    _create_toysoap(create_virtual_snapshot=True)
+def sgs_soap(tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    membership_filebase = tp / _toysoap_membership_filebase.name
+    toysoap_filename = tp / _toysoap_filename.name
+    toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
+    _create_toysnap(snapfile=toysnap_filename, withfof=True)
+    _create_toysoap(
+        filename=toysoap_filename,
+        membership_filebase=membership_filebase,
+        create_virtual_snapshot=True,
+        create_virtual_snapshot_from=toysnap_filename,
+        virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+    )
 
     yield SWIFTGalaxies(
-        _toysoap_virtual_snapshot_filename,
+        toysoap_virtual_snapshot_filename,
         SOAP(
-            soap_file=_toysoap_filename,
+            soap_file=toysoap_filename,
             soap_index=[0, 1],
         ),
         transforms_like_coordinates={"coordinates", "extra_coordinates"},
@@ -176,34 +241,44 @@ def sgs_soap():
         },
     )
 
-    _remove_toysnap()
-    _remove_toysoap()
+    _remove_toysnap(snapfile=toysnap_filename)
+    _remove_toysoap(
+        filename=toysoap_filename,
+        membership_filebase=membership_filebase,
+        virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+    )
 
 
 @pytest.fixture(scope="function")
-def sg_vr():
-    _create_toysnap()
-    _create_toyvr()
+def sg_vr(tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    toyvr_filebase = tp / _toyvr_filebase.name
+    _create_toysnap(snapfile=toysnap_filename)
+    _create_toyvr(filebase=toyvr_filebase)
 
     yield SWIFTGalaxy(
-        _toysnap_filename,
-        Velociraptor(velociraptor_filebase=_toyvr_filebase, halo_index=0),
+        toysnap_filename,
+        Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=0),
         transforms_like_coordinates={"coordinates", "extra_coordinates"},
         transforms_like_velocities={"velocities", "extra_velocities"},
     )
 
-    _remove_toysnap()
-    _remove_toyvr()
+    _remove_toysnap(snapfile=toysnap_filename)
+    _remove_toyvr(filebase=toyvr_filebase)
 
 
 @pytest.fixture(scope="function")
-def sgs_vr():
-    _create_toysnap()
-    _create_toyvr()
+def sgs_vr(tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    toyvr_filebase = tp / _toyvr_filebase.name
+    _create_toysnap(snapfile=toysnap_filename)
+    _create_toyvr(filebase=toyvr_filebase)
 
     yield SWIFTGalaxies(
-        _toysnap_filename,
-        Velociraptor(velociraptor_filebase=_toyvr_filebase, halo_index=[0, 1]),
+        toysnap_filename,
+        Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=[0, 1]),
         transforms_like_coordinates={"coordinates", "extra_coordinates"},
         transforms_like_velocities={"velocities", "extra_velocities"},
         preload={  # just to keep warnings quiet
@@ -212,37 +287,41 @@ def sgs_vr():
         },
     )
 
-    _remove_toysnap()
-    _remove_toyvr()
+    _remove_toysnap(snapfile=toysnap_filename)
+    _remove_toyvr(filebase=toyvr_filebase)
 
 
 @pytest.fixture(scope="function", params=["halo", "galaxy"])
-def sg_caesar(request):
-    _create_toysnap()
-    _create_toycaesar()
+def sg_caesar(request, tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    toycaesar_filename = tp / _toycaesar_filename.name
+    _create_toysnap(snapfile=toysnap_filename)
+    _create_toycaesar(filename=toycaesar_filename)
 
     yield SWIFTGalaxy(
-        _toysnap_filename,
-        Caesar(
-            caesar_file=_toycaesar_filename, group_type=request.param, group_index=0
-        ),
+        toysnap_filename,
+        Caesar(caesar_file=toycaesar_filename, group_type=request.param, group_index=0),
         transforms_like_coordinates={"coordinates", "extra_coordinates"},
         transforms_like_velocities={"velocities", "extra_velocities"},
     )
 
-    _remove_toysnap()
-    _remove_toycaesar()
+    _remove_toysnap(snapfile=toysnap_filename)
+    _remove_toycaesar(filename=toycaesar_filename)
 
 
 @pytest.fixture(scope="function", params=["halo", "galaxy"])
-def sgs_caesar(request):
-    _create_toysnap()
-    _create_toycaesar()
+def sgs_caesar(request, tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    toycaesar_filename = tp / _toycaesar_filename.name
+    _create_toysnap(snapfile=toysnap_filename)
+    _create_toycaesar(filename=toycaesar_filename)
 
     yield SWIFTGalaxies(
-        _toysnap_filename,
+        toysnap_filename,
         Caesar(
-            caesar_file=_toycaesar_filename,
+            caesar_file=toycaesar_filename,
             group_type=request.param,
             group_index=[0, 1],
         ),
@@ -254,76 +333,99 @@ def sgs_caesar(request):
         },
     )
 
-    _remove_toysnap()
-    _remove_toycaesar()
+    _remove_toysnap(snapfile=toysnap_filename)
+    _remove_toycaesar(filename=toycaesar_filename)
 
 
 @pytest.fixture(scope="function")
-def soap():
-    _create_toysoap(create_membership=False)
+def soap(tmp_path_factory):
+    toysoap_filename = (
+        tmp_path_factory.mktemp(_toysnap_filename.parent) / _toysoap_filename.name
+    )
+    _create_toysoap(filename=toysoap_filename, create_membership=False)
 
     yield SOAP(
-        soap_file=_toysoap_filename,
+        soap_file=toysoap_filename,
         soap_index=0,
     )
 
-    _remove_toysoap()
+    _remove_toysoap(
+        filename=toysoap_filename,
+    )
 
 
 @pytest.fixture(scope="function")
-def soap_multi():
-    _create_toysoap()
+def soap_multi(tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysoap_filename = tp / _toysoap_filename.name
+    membership_filebase = tp / _toysoap_membership_filebase
+    _create_toysoap(filename=toysoap_filename, membership_filebase=membership_filebase)
 
     yield SOAP(
-        soap_file=_toysoap_filename,
+        soap_file=toysoap_filename,
         soap_index=[0, 1],
     )
 
-    _remove_toysoap()
+    _remove_toysoap(
+        filename=toysoap_filename,
+        membership_filebase=membership_filebase,
+    )
 
 
 @pytest.fixture(scope="function")
-def vr():
-    _create_toyvr()
+def vr(tmp_path_factory):
+    toyvr_filebase = (
+        tmp_path_factory.mktemp(_toyvr_filebase.parent) / _toyvr_filebase.name
+    )
+    _create_toyvr(filebase=toyvr_filebase)
 
-    yield Velociraptor(velociraptor_filebase=_toyvr_filebase, halo_index=0)
+    yield Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=0)
 
-    _remove_toyvr()
+    _remove_toyvr(filebase=toyvr_filebase)
 
 
 @pytest.fixture(scope="function")
-def vr_multi():
-    _create_toyvr()
+def vr_multi(tmp_path_factory):
+    toyvr_filebase = (
+        tmp_path_factory.mktemp(_toyvr_filebase.parent) / _toyvr_filebase.name
+    )
+    _create_toyvr(filebase=toyvr_filebase)
 
-    yield Velociraptor(velociraptor_filebase=_toyvr_filebase, halo_index=[0, 1])
+    yield Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=[0, 1])
 
-    _remove_toyvr()
+    _remove_toyvr(filebase=toyvr_filebase)
 
 
 @pytest.fixture(scope="function", params=["halo", "galaxy"])
-def caesar(request):
-    _create_toycaesar()
+def caesar(request, tmp_path_factory):
+    toycaesar_filename = (
+        tmp_path_factory.mktemp(_toycaesar_filename.parent) / _toycaesar_filename.name
+    )
+    _create_toycaesar(filename=toycaesar_filename)
 
     yield Caesar(
-        caesar_file=_toycaesar_filename, group_type=request.param, group_index=0
+        caesar_file=toycaesar_filename, group_type=request.param, group_index=0
     )
 
-    _remove_toycaesar()
+    _remove_toycaesar(filename=toycaesar_filename)
 
 
 @pytest.fixture(scope="function", params=["halo", "galaxy"])
-def caesar_multi(request):
-    _create_toycaesar()
+def caesar_multi(request, tmp_path_factory):
+    toycaesar_filename = (
+        tmp_path_factory.mktemp(_toycaesar_filename.parent) / _toycaesar_filename.name
+    )
+    _create_toycaesar(filename=toycaesar_filename)
 
     yield Caesar(
-        caesar_file=_toycaesar_filename, group_type=request.param, group_index=[0, 1]
+        caesar_file=toycaesar_filename, group_type=request.param, group_index=[0, 1]
     )
 
-    _remove_toycaesar()
+    _remove_toycaesar(filename=toycaesar_filename)
 
 
 @pytest.fixture(scope="function")
-def sa():
+def sa(tmp_path_factory):
     yield Standalone(
         extra_mask=MaskCollection(
             gas=np.s_[_n_g_b // 2 :],
@@ -356,7 +458,7 @@ def sa():
 
 
 @pytest.fixture(scope="function")
-def sa_multi():
+def sa_multi(tmp_path_factory):
     yield Standalone(
         extra_mask=None,
         centre=cosmo_array(
@@ -390,10 +492,12 @@ def sa_multi():
 
 
 @pytest.fixture(scope="function")
-def sg_sa():
-    _create_toysnap()
+def sg_sa(tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    _create_toysnap(snapfile=toysnap_filename)
     yield SWIFTGalaxy(
-        _toysnap_filename,
+        toysnap_filename,
         Standalone(
             extra_mask=MaskCollection(
                 gas=np.s_[_n_g_b // 2 :],
@@ -424,14 +528,16 @@ def sg_sa():
             ),
         ),
     )
-    _remove_toysnap()
+    _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function")
-def sgs_sa():
-    _create_toysnap()
+def sgs_sa(tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    _create_toysnap(snapfile=toysnap_filename)
     yield SWIFTGalaxies(
-        _toysnap_filename,
+        toysnap_filename,
         Standalone(
             extra_mask=None,
             centre=cosmo_array(
@@ -467,46 +573,63 @@ def sgs_sa():
             "dark_matter.particle_ids",
         },
     )
-    _remove_toysnap()
+    _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function", params=hfs)
-def sg_hf(request):
-    _create_toysnap(withfof=request.param == "soap")
+def sg_hf(request, tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    _create_toysnap(snapfile=toysnap_filename, withfof=request.param == "soap")
     if request.param in {"caesar_halo", "caesar_galaxy"}:
-        _create_toycaesar()
+        toycaesar_filename = tp / _toycaesar_filename.name
+        _create_toycaesar(filename=toycaesar_filename)
         yield SWIFTGalaxy(
-            _toysnap_filename,
+            toysnap_filename,
             Caesar(
-                caesar_file=_toycaesar_filename,
+                caesar_file=toycaesar_filename,
                 group_type=request.param.split("_")[-1],
                 group_index=0,
             ),
             transforms_like_coordinates={"coordinates", "extra_coordinates"},
             transforms_like_velocities={"velocities", "extra_velocities"},
         )
-        _remove_toycaesar()
+        _remove_toycaesar(filename=toycaesar_filename)
     elif request.param == "soap":
-        _create_toysoap(create_virtual_snapshot=True)
+        toysoap_filename = tp / _toysoap_filename.name
+        membership_filebase = tp / _toysoap_membership_filebase.name
+        toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
+        _create_toysoap(
+            filename=toysoap_filename,
+            membership_filebase=membership_filebase,
+            create_virtual_snapshot=True,
+            create_virtual_snapshot_from=toysnap_filename,
+            virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+        )
         yield SWIFTGalaxy(
-            _toysoap_virtual_snapshot_filename,
+            toysoap_virtual_snapshot_filename,
             SOAP(
-                soap_file=_toysoap_filename,
+                soap_file=toysoap_filename,
                 soap_index=0,
             ),
             transforms_like_coordinates={"coordinates", "extra_coordinates"},
             transforms_like_velocities={"velocities", "extra_velocities"},
         )
-        _remove_toysoap()
+        _remove_toysoap(
+            filename=toysoap_filename,
+            membership_filebase=membership_filebase,
+            virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+        )
     elif request.param == "vr":
-        _create_toyvr()
+        toyvr_filebase = tp / _toyvr_filebase.name
+        _create_toyvr(filebase=toyvr_filebase)
         yield SWIFTGalaxy(
-            _toysnap_filename,
-            Velociraptor(velociraptor_filebase=_toyvr_filebase, halo_index=0),
+            toysnap_filename,
+            Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=0),
             transforms_like_coordinates={"coordinates", "extra_coordinates"},
             transforms_like_velocities={"velocities", "extra_velocities"},
         )
-        _remove_toyvr()
+        _remove_toyvr(filebase=toyvr_filebase)
     elif request.param == "sa":
         yield Standalone(
             extra_mask=MaskCollection(
@@ -537,36 +660,46 @@ def sg_hf(request):
                 scale_exponent=1,
             ),
         )
-    _remove_toysnap()
+        _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function", params=hfs)
-def hf(request):
+def hf(request, tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
     if request.param in {"caesar_halo", "caesar_galaxy"}:
-        _create_toycaesar()
+        toycaesar_filename = tp / _toycaesar_filename.name
+        _create_toycaesar(filename=toycaesar_filename)
 
         yield Caesar(
-            caesar_file=_toycaesar_filename,
+            caesar_file=toycaesar_filename,
             group_type=request.param.split("_")[-1],
             group_index=0,
         )
 
-        _remove_toycaesar()
+        _remove_toycaesar(filename=toycaesar_filename)
     elif request.param == "soap":
-        _create_toysoap()
+        toysoap_filename = tp / _toysoap_filename.name
+        membership_filebase = tp / _toysoap_membership_filebase.name
+        _create_toysoap(
+            filename=toysoap_filename, membership_filebase=membership_filebase
+        )
 
         yield SOAP(
-            soap_file=_toysoap_filename,
+            soap_file=toysoap_filename,
             soap_index=0,
         )
 
-        _remove_toysoap()
+        _remove_toysoap(
+            filename=toysoap_filename,
+            membership_filebase=membership_filebase,
+        )
     elif request.param == "vr":
-        _create_toyvr()
+        toyvr_filebase = tp / _toyvr_filebase.name
+        _create_toyvr(filebase=toyvr_filebase)
 
-        yield Velociraptor(velociraptor_filebase=_toyvr_filebase, halo_index=0)
+        yield Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=0)
 
-        _remove_toyvr()
+        _remove_toyvr(filebase=toyvr_filebase)
     elif request.param == "sa":
         yield Standalone(
             extra_mask=MaskCollection(
@@ -600,32 +733,51 @@ def hf(request):
 
 
 @pytest.fixture(scope="function", params=hfs)
-def hf_multi(request):
+def hf_multi(request, tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    _create_toysnap(snapfile=toysnap_filename, withfof=request.param == "soap")
     if request.param in {"caesar_halo", "caesar_galaxy"}:
-        _create_toycaesar()
+        toycaesar_filename = tp / _toycaesar_filename.name
+        _create_toycaesar(filename=toycaesar_filename)
 
         yield Caesar(
-            caesar_file=_toycaesar_filename,
+            caesar_file=toycaesar_filename,
             group_type=request.param.split("_")[-1],
             group_index=[0, 1],
         )
 
-        _remove_toycaesar()
+        _remove_toycaesar(filename=toycaesar_filename)
     elif request.param == "soap":
-        _create_toysoap(create_virtual_snapshot=Path(_toysnap_filename).is_file())
+        toysoap_filename = tp / _toysoap_filename.name
+        membership_filebase = tp / _toysoap_membership_filebase.name
+        toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
+        _create_toysoap(
+            filename=toysoap_filename,
+            membership_filebase=membership_filebase,
+            create_virtual_snapshot=Path(toysnap_filename).is_file(),
+            create_virtual_snapshot_from=toysnap_filename,
+            virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+        )
 
         yield SOAP(
-            soap_file=_toysoap_filename,
+            soap_file=toysoap_filename,
             soap_index=[0, 1],
         )
 
-        _remove_toysoap()
+        _remove_toysoap(
+            filename=toysoap_filename,
+            membership_filebase=membership_filebase,
+            virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+        )
+
     elif request.param == "vr":
-        _create_toyvr()
+        toyvr_filebase = tp / _toyvr_filebase.name
+        _create_toyvr(filebase=toyvr_filebase)
 
-        yield Velociraptor(velociraptor_filebase=_toyvr_filebase, halo_index=[0, 1])
+        yield Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=[0, 1])
 
-        _remove_toyvr()
+        _remove_toyvr(filebase=toyvr_filebase)
     elif request.param == "sa":
         yield Standalone(
             extra_mask=None,
@@ -657,44 +809,63 @@ def hf_multi(request):
                 scale_exponent=1,
             ),
         )
+    _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function", params=hfs)
-def hf_multi_forwards_and_backwards(request):
+def hf_multi_forwards_and_backwards(request, tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    _create_toysnap(snapfile=toysnap_filename, withfof=request.param == "soap")
     if request.param in {"caesar_halo", "caesar_galaxy"}:
-        _create_toycaesar()
+        toycaesar_filename = tp / _toycaesar_filename.name
+        _create_toycaesar(filename=toycaesar_filename)
 
         yield Caesar(
-            caesar_file=_toycaesar_filename,
+            caesar_file=toycaesar_filename,
             group_type=request.param.split("_")[-1],
             group_index=[0, 1],
         ), Caesar(
-            caesar_file=_toycaesar_filename,
+            caesar_file=toycaesar_filename,
             group_type=request.param.split("_")[-1],
             group_index=[1, 0],
         )
 
-        _remove_toycaesar()
+        _remove_toycaesar(filename=toycaesar_filename)
     elif request.param == "soap":
-        _create_toysoap(create_virtual_snapshot=Path(_toysnap_filename).is_file())
+        toysoap_filename = tp / _toysoap_filename.name
+        membership_filebase = tp / _toysoap_membership_filebase.name
+        toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
+        _create_toysoap(
+            filename=toysoap_filename,
+            membership_filebase=membership_filebase,
+            create_virtual_snapshot=Path(toysnap_filename).is_file(),
+            create_virtual_snapshot_from=toysnap_filename,
+            virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+        )
 
         yield SOAP(
-            soap_file=_toysoap_filename,
+            soap_file=toysoap_filename,
             soap_index=[0, 1],
         ), SOAP(
-            soap_file=_toysoap_filename,
+            soap_file=toysoap_filename,
             soap_index=[1, 0],
         )
 
-        _remove_toysoap()
+        _remove_toysoap(
+            filename=toysoap_filename,
+            membership_filebase=membership_filebase,
+            virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+        )
     elif request.param == "vr":
-        _create_toyvr()
+        toyvr_filebase = tp / _toyvr_filebase.name
+        _create_toyvr(filebase=toyvr_filebase)
 
         yield Velociraptor(
-            velociraptor_filebase=_toyvr_filebase, halo_index=[0, 1]
-        ), Velociraptor(velociraptor_filebase=_toyvr_filebase, halo_index=[1, 0])
+            velociraptor_filebase=toyvr_filebase, halo_index=[0, 1]
+        ), Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=[1, 0])
 
-        _remove_toyvr()
+        _remove_toyvr(filebase=toyvr_filebase)
     elif request.param == "sa":
         yield Standalone(
             extra_mask=None,
@@ -755,35 +926,54 @@ def hf_multi_forwards_and_backwards(request):
                 scale_exponent=1,
             ),
         )
+    _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function", params=hfs)
-def hf_multi_onetarget(request):
+def hf_multi_onetarget(request, tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    _create_toysnap(snapfile=toysnap_filename, withfof=request.param == "soap")
     if request.param in {"caesar_halo", "caesar_galaxy"}:
-        _create_toycaesar()
+        toycaesar_filename = tp / _toycaesar_filename.name
+        _create_toycaesar(filename=toycaesar_filename)
 
         yield Caesar(
-            caesar_file=_toycaesar_filename,
+            caesar_file=toycaesar_filename,
             group_type=request.param.split("_")[-1],
             group_index=[1],
         )
 
-        _remove_toycaesar()
+        _remove_toycaesar(filename=toycaesar_filename)
     elif request.param == "soap":
-        _create_toysoap(create_virtual_snapshot=Path(_toysnap_filename).is_file())
+        toysoap_filename = tp / _toysoap_filename.name
+        membership_filebase = tp / _toysoap_membership_filebase.name
+        toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
+        _create_toysoap(
+            filename=toysoap_filename,
+            membership_filebase=membership_filebase,
+            create_virtual_snapshot=Path(toysnap_filename).is_file(),
+            create_virtual_snapshot_from=toysnap_filename,
+            virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+        )
 
         yield SOAP(
-            soap_file=_toysoap_filename,
+            soap_file=toysoap_filename,
             soap_index=[1],
         )
 
-        _remove_toysoap()
+        _remove_toysoap(
+            filename=toysoap_filename,
+            membership_filebase=membership_filebase,
+            virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+        )
     elif request.param == "vr":
-        _create_toyvr()
+        toyvr_filebase = tp / _toyvr_filebase.name
+        _create_toyvr(filebase=toyvr_filebase)
 
-        yield Velociraptor(velociraptor_filebase=_toyvr_filebase, halo_index=[1])
+        yield Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=[1])
 
-        _remove_toyvr()
+        _remove_toyvr(filebase=toyvr_filebase)
     elif request.param == "sa":
         yield Standalone(
             extra_mask=None,
@@ -813,35 +1003,54 @@ def hf_multi_onetarget(request):
                 scale_exponent=1,
             ),
         )
+    _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function", params=hfs)
-def hf_multi_zerotarget(request):
+def hf_multi_zerotarget(request, tmp_path_factory):
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    _create_toysnap(snapfile=toysnap_filename, withfof=request.param == "soap")
     if request.param in {"caesar_halo", "caesar_galaxy"}:
-        _create_toycaesar()
+        toycaesar_filename = tp / _toycaesar_filename.name
+        _create_toycaesar(filename=toycaesar_filename)
 
         yield Caesar(
-            caesar_file=_toycaesar_filename,
+            caesar_file=toycaesar_filename,
             group_type=request.param.split("_")[-1],
             group_index=[],
         )
 
-        _remove_toycaesar()
+        _remove_toycaesar(filename=toycaesar_filename)
     elif request.param == "soap":
-        _create_toysoap(create_virtual_snapshot=Path(_toysnap_filename).is_file())
+        toysoap_filename = tp / _toysoap_filename.name
+        membership_filebase = tp / _toysoap_membership_filebase.name
+        toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
+        _create_toysoap(
+            filename=toysoap_filename,
+            membership_filebase=membership_filebase,
+            create_virtual_snapshot=Path(toysnap_filename).is_file(),
+            create_virtual_snapshot_from=toysnap_filename,
+            virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+        )
 
         yield SOAP(
-            soap_file=_toysoap_filename,
+            soap_file=toysoap_filename,
             soap_index=[],
         )
 
-        _remove_toysoap()
+        _remove_toysoap(
+            filename=toysoap_filename,
+            membership_filebase=membership_filebase,
+            virtual_snapshot_filename=toysoap_virtual_snapshot_filename,
+        )
     elif request.param == "vr":
-        _create_toyvr()
+        toyvr_filebase = tp / _toyvr_filebase.name
+        _create_toyvr(filebase=toyvr_filebase)
 
-        yield Velociraptor(velociraptor_filebase=_toyvr_filebase, halo_index=[])
+        yield Velociraptor(velociraptor_filebase=toyvr_filebase, halo_index=[])
 
-        _remove_toyvr()
+        _remove_toyvr(filebase=toyvr_filebase)
     elif request.param == "sa":
         yield Standalone(
             extra_mask=None,
@@ -867,6 +1076,7 @@ def hf_multi_zerotarget(request):
                 scale_exponent=1,
             ),
         )
+    _remove_toysnap(snapfile=toysnap_filename)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_coordinate_transformations.py
+++ b/tests/test_coordinate_transformations.py
@@ -6,10 +6,7 @@ from swiftsimio.objects import cosmo_array, cosmo_quantity
 from scipy.spatial.transform import Rotation
 from swiftgalaxy.demo_data import (
     _present_particle_types,
-    _toysnap_filename,
     ToyHF,
-    _create_toysnap,
-    _remove_toysnap,
 )
 from swiftgalaxy import SWIFTGalaxy
 from swiftgalaxy.reader import _apply_translation, _apply_4transform
@@ -647,7 +644,10 @@ class TestCopyingTransformations:
             match="Cannot use coordinate_frame_from with auto_recentre=True.",
         ):
             SWIFTGalaxy(
-                _toysnap_filename, ToyHF(), auto_recentre=True, coordinate_frame_from=sg
+                sg.filename,
+                ToyHF(snapfile=sg.filename),
+                auto_recentre=True,
+                coordinate_frame_from=sg,
             )
 
     def test_invalid_coordinate_frame_from(self, sg):
@@ -657,19 +657,13 @@ class TestCopyingTransformations:
         new_time_unit = u.s
         assert sg.metadata.units.time != new_time_unit
         sg.metadata.units.time = new_time_unit
-        try:
-            _create_toysnap()
-            with pytest.raises(
-                ValueError, match="Internal units \\(length and time\\) of"
-            ):
-                SWIFTGalaxy(
-                    _toysnap_filename,
-                    ToyHF(),
-                    coordinate_frame_from=sg,
-                    auto_recentre=False,
-                )
-        finally:
-            _remove_toysnap()
+        with pytest.raises(ValueError, match="Internal units \\(length and time\\) of"):
+            SWIFTGalaxy(
+                sg.filename,
+                ToyHF(snapfile=sg.filename),
+                coordinate_frame_from=sg,
+                auto_recentre=False,
+            )
 
     def test_copied_coordinate_transform(self, sg):
         """
@@ -686,7 +680,10 @@ class TestCopyingTransformations:
         )
         sg.translate(translation)
         sg2 = SWIFTGalaxy(
-            _toysnap_filename, ToyHF(), auto_recentre=False, coordinate_frame_from=sg
+            sg.filename,
+            ToyHF(snapfile=sg.filename),
+            auto_recentre=False,
+            coordinate_frame_from=sg,
         )
         assert_allclose_units(
             sg.gas.coordinates, sg2.gas.coordinates, rtol=1.0e-4, atol=abstol_c
@@ -707,7 +704,10 @@ class TestCopyingTransformations:
         )
         sg.translate(translation)
         sg2 = SWIFTGalaxy(
-            _toysnap_filename, ToyHF(), auto_recentre=False, coordinate_frame_from=sg
+            sg.filename,
+            ToyHF(snapfile=sg.filename),
+            auto_recentre=False,
+            coordinate_frame_from=sg,
         )
         assert_allclose_units(
             sg.gas.velocities, sg2.gas.velocities, rtol=1.0e-4, atol=abstol_v

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -4,8 +4,6 @@ import unyt as u
 from swiftsimio import cosmo_array, mask
 from swiftgalaxy import SWIFTGalaxy, Velociraptor, Caesar, SOAP, Standalone
 from swiftgalaxy.demo_data import (
-    web_examples,
-    generated_examples,
     ToyHF,
     _toysnap_filename,
     _toyvr_filebase,
@@ -14,18 +12,6 @@ from swiftgalaxy.demo_data import (
     _toysoap_virtual_snapshot_filename,
     _toycaesar_filename,
 )
-
-
-@pytest.fixture(scope="session")
-def generated_examples_tmpdir(tmp_path_factory):
-    generated_examples._demo_data_dir = tmp_path_factory.mktemp("demo_data")
-    return generated_examples
-
-
-@pytest.fixture(scope="session")
-def web_examples_tmpdir(tmp_path_factory):
-    web_examples._demo_data_dir = tmp_path_factory.mktemp("demo_data")
-    return web_examples
 
 
 class TestWebExampleData:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -190,7 +190,7 @@ class TestGeneratedExampleData:
 
 class TestExampleNotebooks:
 
-    def test_generated_example_notebook(self, generated_examples_tmpdir):
+    def test_generated_example_notebook(self):
         """
         Check that the example notebook with data generated on the fly runs without error.
         """
@@ -199,13 +199,8 @@ class TestExampleNotebooks:
         )
         from nbmake.nb_run import NotebookRun
         from nbmake.pytest_items import NotebookFailedException
-        import pathlib
 
-        generated_examples_tmpdir.remove()
-        nbr = NotebookRun(pathlib.Path("examples/SWIFTGalaxy_demo.ipynb"), 300)
-        try:
-            result = nbr.execute()
-            if result.error is not None:
-                raise NotebookFailedException(result)
-        finally:
-            generated_examples_tmpdir.remove()
+        nbr = NotebookRun(Path("examples/SWIFTGalaxy_demo.ipynb"), 300)
+        result = nbr.execute()
+        if result.error is not None:
+            raise NotebookFailedException(result)

--- a/tests/test_halo_catalogues.py
+++ b/tests/test_halo_catalogues.py
@@ -1009,8 +1009,12 @@ class TestCaesarWithSWIFTGalaxy:
         Check that we can tolerate missing particle membership information for arbitrary
         particle types in a caesar catalogue.
         """
+        toycaesar_filename = (
+            toysnap["toysnap_filename"].parent / _toycaesar_filename.name
+        )
         try:
             _create_toycaesar(
+                filename=toycaesar_filename,
                 include_slist=False,
                 include_glist=False,
                 include_bhlist=False,
@@ -1018,14 +1022,14 @@ class TestCaesarWithSWIFTGalaxy:
             )
             sg = SWIFTGalaxy(
                 toysnap["toysnap_filename"],
-                Caesar(_toycaesar_filename, group_type=group_type, group_index=0),
+                Caesar(toycaesar_filename, group_type=group_type, group_index=0),
             )
             assert sg._extra_mask.gas.mask == np.s_[:0]
             assert sg._extra_mask.stars.mask == np.s_[:0]
             assert sg._extra_mask.dark_matter.mask == np.s_[:0]
             assert sg._extra_mask.black_holes.mask == np.s_[:0]
         finally:
-            _remove_toycaesar()
+            _remove_toycaesar(filename=toycaesar_filename)
 
     def test_lazy_masking_sg(self, sg_caesar):
         """

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -96,16 +96,19 @@ class TestMaskingSWIFTGalaxy:
             neutral_before[mask], neutral, rtol=reltol_nd, atol=abstol_nd
         )
 
-    def test_mask_without_spatial_mask(self):
+    def test_mask_without_spatial_mask(self, tmp_path_factory):
         """
         Check that if we have no masks we read everything in the box (and warn about it).
         Then that we can still apply an extra mask, and a second one (there's specific
         logic for applying two consecutively).
         """
+        toysnap_filename = (
+            tmp_path_factory.mktemp(_toysnap_filename.parent) / _toysnap_filename.name
+        )
         try:
-            _create_toysnap()
+            _create_toysnap(snapfile=toysnap_filename)
             sg = SWIFTGalaxy(
-                _toysnap_filename,
+                toysnap_filename,
                 None,  # no halo_catalogue is easiest way to get no mask
                 transforms_like_coordinates={"coordinates", "extra_coordinates"},
                 transforms_like_velocities={"velocities", "extra_velocities"},
@@ -129,7 +132,7 @@ class TestMaskingSWIFTGalaxy:
             sg.mask_particles(MaskCollection(gas=np.s_[:100]))
             assert sg.gas.masses.size == 100
         finally:
-            _remove_toysnap()
+            _remove_toysnap(snapfile=toysnap_filename)
 
 
 class TestMaskingParticleDatasets:

--- a/tests/test_visualisation.py
+++ b/tests/test_visualisation.py
@@ -5,16 +5,20 @@ from swiftsimio import cosmo_array, cosmo_quantity
 from swiftsimio.visualisation.projection import project_gas
 from swiftsimio.visualisation.slice import slice_gas
 from swiftsimio.visualisation.volume_render import render_gas
+from swiftgalaxy import SWIFTGalaxy
 
 
 @pytest.mark.parametrize("periodic", [False, True])
 class TestRecenteredVisualisation:
 
     @pytest.mark.parametrize("z_cut", [False, True])
-    def test_recentered_projection(self, sg, sg_autorecentre_off, z_cut, periodic):
+    def test_recentered_projection(self, sg_autorecentre_off, z_cut, periodic):
         """
         We should be able to make the same projections whether we recentered or not.
         """
+        sg = SWIFTGalaxy(
+            sg_autorecentre_off.snapshot_filename, sg_autorecentre_off.halo_catalogue
+        )
         z_limits = [1.9, 2.1] if z_cut else []
         recentered_z_limits = [-0.1, 0.1] if z_cut else []
         kwargs = {
@@ -48,10 +52,13 @@ class TestRecenteredVisualisation:
         assert (ref_img > 0).any()
         assert np.allclose(ref_img, recentered_img)
 
-    def test_recentered_slice(self, sg, sg_autorecentre_off, periodic):
+    def test_recentered_slice(self, sg_autorecentre_off, periodic):
         """
         We should be able to make the same slice whether we recentered or not.
         """
+        sg = SWIFTGalaxy(
+            sg_autorecentre_off.snapshot_filename, sg_autorecentre_off.halo_catalogue
+        )
         z_slice = cosmo_quantity(
             1.95, u.Mpc, comoving=True, scale_factor=1, scale_exponent=1
         )
@@ -91,10 +98,13 @@ class TestRecenteredVisualisation:
         assert (ref_img > 0).any()
         assert np.allclose(ref_img, recentered_img)
 
-    def test_recentered_volume_render(self, sg, sg_autorecentre_off, periodic):
+    def test_recentered_volume_render(self, sg_autorecentre_off, periodic):
         """
         We should be able to make the same rendering whether we recentered or not.
         """
+        sg = SWIFTGalaxy(
+            sg_autorecentre_off.snapshot_filename, sg_autorecentre_off.halo_catalogue
+        )
         kwargs = {
             "resolution": 4,
             "project": "masses",


### PR DESCRIPTION
Previously the test suite would create and delete many temporary data files as the suite ran. This could lead to unexpected failures if these were ever not cleaned up after a run of the suite (e.g. if a failure/interruption prevented automated cleanup from running). It also precluded running the suite in parallel because of processes competing to create/delete the same files (from test fixtures).

This PR moves *almost* all files created/destroyed in testing to temporary directories using the [`tmp_path` feature](https://docs.pytest.org/en/stable/how-to/tmp_path.html) in pytest. The only exception is the notebook, because of limitations on passing information into the notebook kernel in [`nbmake`](https://github.com/treebeardtech/nbmake). Circumventing this is awkward without changes to `nbmake` itself (I've asked the dev), so for now leaving that alone. I did however change the functions that remove sample data so that the test suite will properly clean up after itself.

Small things left to do:
- [ ] Notebook could be set to use a different data directory during pytest runs (through the `post_cell_execute` feature). This helps to avoid deleting a developer's actual copy of the data during testing, or pre-existing data messing with the test run. Of course ideally actual temporary directories would be used instead.
- [ ] Probably some coverage misses to be handled.