### PR TITLE
Replace wget call with requests

### DIFF
--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -5,7 +5,7 @@ black[jupyter]
 mypy
 numpydoc
 nbmake
-h5py
+tqdm
 astropy
 velociraptor
 git+https://github.com/dnarayanan/caesar.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 "Documentation" = "https://swiftgalaxy.readthedocs.io/en/latest"
 
 [project.optional-dependencies]
-velociraptor = ["velociraptor"]
+velociraptor = ["velociraptor", "tqdm"]
 
 [tool.numpydoc_validation]
 checks = [


### PR DESCRIPTION
Fetching files with `wget` is not platform independent, this PR replaces `wget` with the `requests` module to remedy this.

Closes #65 