### PR TITLE
Enable testing on windows and macos platforms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy>=2.0.0
 scipy
 unyt
-#swiftsimio>=10.0.0
-git+https://github.com/SWIFTSIM/swiftsimio.git@close_handle
+swiftsimio>=10.0.0
 requests


### PR DESCRIPTION
Closes #55 
Depends on SWIFTSIM/swiftsimio#258

With better management of file opening/closing on the swiftsimio side, and using requests instead of wget, the swiftgalaxy test suite should be able to run on windows and macos platforms.

- [x] Once the swiftsimio patch merges (now merged) and *releases* (not yet), reset the dependency to the pypi version. Then this can be merged if tests pass.