### PR TITLE
Update usage for new location of `SOAP.compression`

### DIFF
--- a/swiftgalaxy/demo_data.py
+++ b/swiftgalaxy/demo_data.py
@@ -3179,25 +3179,14 @@ def _create_toysoap(
                     ds_rank.attrs["h-scale exponent"] = np.array([0.0])
     if create_virtual_snapshot:
         if not Path(virtual_snapshot_filename).is_file():
-            from compression.make_virtual_snapshot import make_virtual_snapshot
-            from compression.update_vds_paths import update_virtual_snapshot_paths
+            from SOAP.compression.make_virtual_snapshot import make_virtual_snapshot
 
             membership_filepattern = str(membership_filebase) + ".{file_nr}.hdf5"
             make_virtual_snapshot(
                 create_virtual_snapshot_from,
-                membership_filepattern,
+                [membership_filepattern],
                 virtual_snapshot_filename,
-                0,  # snapshot number, not used since no pattern in filenames
-            )
-            abs_snapshot_dir = Path(create_virtual_snapshot_from).parent.absolute()
-            abs_membership_dir = Path(
-                membership_filepattern.format(file_nr=0)
-            ).parent.absolute()
-            abs_output_dir = Path(virtual_snapshot_filename).parent.absolute()
-            rel_snapshot_dir = abs_snapshot_dir.relative_to(abs_output_dir)
-            rel_membership_dir = abs_membership_dir.relative_to(abs_output_dir)
-            update_virtual_snapshot_paths(
-                virtual_snapshot_filename, rel_snapshot_dir, rel_membership_dir
+                absolute_paths=True,
             )
     return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,7 +113,7 @@ def toysoap_with_virtual_snapshot(tmp_path_factory: TempPathFactory) -> dict[str
     dict
         Dictionary with created file locations.
     """
-    pytest.importorskip("compression")
+    pytest.importorskip("SOAP.compression")
     tp = tmp_path_factory.mktemp(_toysoap_filename.parent)
     toysoap_filename = tp / _toysoap_filename.name
     membership_filebase = tp / _toysoap_membership_filebase.name
@@ -289,7 +289,7 @@ def sg_soap(tmp_path_factory: TempPathFactory) -> SWIFTGalaxy:
         A :class:`~swiftgalaxy.reader.SWIFTGalaxy` with
         :class:`~swiftgalaxy.halo_catalogues.SOAP` halo catalogue.
     """
-    pytest.importorskip("compression")
+    pytest.importorskip("SOAP.compression")
     tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
     toysnap_filename = tp / _toysnap_filename.name
     toysoap_filename = tp / _toysoap_filename.name
@@ -340,7 +340,7 @@ def sgs_soap(tmp_path_factory: TempPathFactory) -> SWIFTGalaxies:
         A :class:`~swiftgalaxy.iterator.SWIFTGalaxies` with
         :class:`~swiftgalaxy.halo_catalogues.SOAP` halo catalogue.
     """
-    pytest.importorskip("compression")
+    pytest.importorskip("SOAP.compression")
     tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
     toysnap_filename = tp / _toysnap_filename.name
     membership_filebase = tp / _toysoap_membership_filebase.name
@@ -546,7 +546,7 @@ def soap(tmp_path_factory: TempPathFactory) -> SOAP:
     ~swiftgalaxy.halo_catalogues.SOAP
         A :class:`~swiftgalaxy.halo_catalogue.SOAP` halo catalogue.
     """
-    # no virtual snapshot needed, don't need importorskip("compression")
+    # no virtual snapshot needed, don't need importorskip("SOAP.compression")
     toysoap_filename = (
         tmp_path_factory.mktemp(_toysnap_filename.parent) / _toysoap_filename.name
     )
@@ -579,7 +579,7 @@ def soap_multi(tmp_path_factory: TempPathFactory) -> SOAP:
     ~swiftgalaxy.halo_catalogues.SOAP
         A :class:`~swiftgalaxy.halo_catalogue.SOAP` halo catalogue with multiple targets.
     """
-    # no virtual snapshot needed, don't need importorskip("compression")
+    # no virtual snapshot needed, don't need importorskip("SOAP.compression")
     tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
     toysoap_filename = tp / _toysoap_filename.name
     membership_filebase = tp / _toysoap_membership_filebase
@@ -963,7 +963,7 @@ def sg_hf(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> SWIFTGa
         )
         _remove_toycaesar(filename=toycaesar_filename)
     elif request.param == "soap":
-        pytest.importorskip("compression")
+        pytest.importorskip("SOAP.compression")
         toysoap_filename = tp / _toysoap_filename.name
         membership_filebase = tp / _toysoap_membership_filebase.name
         toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
@@ -1063,7 +1063,7 @@ def hf(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> _HaloCatal
 
         _remove_toycaesar(filename=toycaesar_filename)
     elif request.param == "soap":
-        # no virtual snapshot needed, don't need pytest.importorskip("compression")
+        # no virtual snapshot needed, don't need pytest.importorskip("SOAP.compression")
         toysoap_filename = tp / _toysoap_filename.name
         membership_filebase = tp / _toysoap_membership_filebase.name
         _create_toysoap(
@@ -1159,7 +1159,7 @@ def hf_multi(
     elif request.param == "soap":
         create_virtual_snapshot = Path(toysnap_filename).is_file()
         if create_virtual_snapshot:
-            pytest.importorskip("compression")
+            pytest.importorskip("SOAP.compression")
         toysoap_filename = tp / _toysoap_filename.name
         membership_filebase = tp / _toysoap_membership_filebase.name
         toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
@@ -1272,7 +1272,7 @@ def hf_multi_forwards_and_backwards(
 
         _remove_toycaesar(filename=toycaesar_filename)
     elif request.param == "soap":
-        pytest.importorskip("compression")
+        pytest.importorskip("SOAP.compression")
         toysoap_filename = tp / _toysoap_filename.name
         membership_filebase = tp / _toysoap_membership_filebase.name
         toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
@@ -1416,7 +1416,7 @@ def hf_multi_onetarget(
 
         _remove_toycaesar(filename=toycaesar_filename)
     elif request.param == "soap":
-        pytest.importorskip("compression")
+        pytest.importorskip("SOAP.compression")
         toysoap_filename = tp / _toysoap_filename.name
         membership_filebase = tp / _toysoap_membership_filebase.name
         toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name
@@ -1520,7 +1520,7 @@ def hf_multi_zerotarget(
     elif request.param == "soap":
         create_virtual_snapshot = Path(toysnap_filename).is_file()
         if create_virtual_snapshot:
-            pytest.importorskip("compression")
+            pytest.importorskip("SOAP.compression")
         toysoap_filename = tp / _toysoap_filename.name
         membership_filebase = tp / _toysoap_membership_filebase.name
         toysoap_virtual_snapshot_filename = tp / _toysoap_virtual_snapshot_filename.name

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -145,7 +145,7 @@ class TestGeneratedExampleData:
 
     def test_soap(self, generated_examples_tmpdir):
         """Check that we can create a swiftgalaxy using the generated soap."""
-        pytest.importorskip("compression")
+        pytest.importorskip("SOAP.compression")
         SWIFTGalaxy(
             generated_examples_tmpdir.virtual_snapshot,
             SOAP(generated_examples_tmpdir.soap, soap_index=0),
@@ -153,7 +153,7 @@ class TestGeneratedExampleData:
 
     def test_remove(self, generated_examples_tmpdir):
         """Check that examples get cleaned up on request."""
-        pytest.importorskip("compression")
+        pytest.importorskip("SOAP.compression")
         # create all the example data (if not present)
         for example in generated_examples_tmpdir.available_examples:
             getattr(generated_examples_tmpdir, example)

--- a/tests/test_halo_catalogues.py
+++ b/tests/test_halo_catalogues.py
@@ -137,9 +137,8 @@ class TestHaloCatalogues:
         """Check that bound_only extra mask has the right shape."""
         hf.extra_mask = "bound_only"
         if hasattr(hf, "soap_file"):
-            pytest.importorskip("compression")
-            from compression.make_virtual_snapshot import make_virtual_snapshot
-            from compression.update_vds_paths import update_virtual_snapshot_paths
+            pytest.importorskip("SOAP.compression")
+            from SOAP.compression.make_virtual_snapshot import make_virtual_snapshot
 
             tp = hf.soap_file.parent
             toysnap_filename = tp / _toysnap_filename.name
@@ -152,19 +151,9 @@ class TestHaloCatalogues:
             )
             make_virtual_snapshot(
                 toysnap_filename,
-                str(membership_filepattern),
+                [str(membership_filepattern)],
                 toysoap_virtual_snapshot_filename,
-                0,  # snapshot number, not used since no pattern in filenames
-            )
-            abs_snapshot_dir = Path(toysnap_filename).parent.absolute()
-            abs_membership_dir = Path(
-                str(membership_filepattern).format(file_nr=0)
-            ).parent.absolute()
-            abs_output_dir = Path(toysoap_virtual_snapshot_filename).parent.absolute()
-            rel_snapshot_dir = abs_snapshot_dir.relative_to(abs_output_dir)
-            rel_membership_dir = abs_membership_dir.relative_to(abs_output_dir)
-            update_virtual_snapshot_paths(
-                toysoap_virtual_snapshot_filename, rel_snapshot_dir, rel_membership_dir
+                absolute_paths=True,
             )
             sg = SWIFTGalaxy(toysoap_virtual_snapshot_filename, hf)
         elif hasattr(hf, "caesar_file"):
@@ -378,9 +367,8 @@ class TestHaloCataloguesMulti:
         hf_multi.extra_mask = "bound_only"
         hf_multi._mask_multi_galaxy(0)
         if hasattr(hf_multi, "soap_file"):
-            pytest.importorskip("compression")
-            from compression.make_virtual_snapshot import make_virtual_snapshot
-            from compression.update_vds_paths import update_virtual_snapshot_paths
+            pytest.importorskip("SOAP.compression")
+            from SOAP.compression.make_virtual_snapshot import make_virtual_snapshot
 
             tp = hf_multi.soap_file.parent
             toysnap_filename = tp / _toysnap_filename.name
@@ -393,19 +381,9 @@ class TestHaloCataloguesMulti:
             )
             make_virtual_snapshot(
                 toysnap_filename,
-                str(membership_filepattern),
+                [str(membership_filepattern)],
                 toysoap_virtual_snapshot_filename,
-                0,  # snapshot number, not used since no pattern in filenames
-            )
-            abs_snapshot_dir = Path(toysnap_filename).parent.absolute()
-            abs_membership_dir = Path(
-                str(membership_filepattern).format(file_nr=0)
-            ).parent.absolute()
-            abs_output_dir = Path(toysoap_virtual_snapshot_filename).parent.absolute()
-            rel_snapshot_dir = abs_snapshot_dir.relative_to(abs_output_dir)
-            rel_membership_dir = abs_membership_dir.relative_to(abs_output_dir)
-            update_virtual_snapshot_paths(
-                toysoap_virtual_snapshot_filename, rel_snapshot_dir, rel_membership_dir
+                absolute_paths=True,
             )
             sg = SWIFTGalaxy(toysoap_virtual_snapshot_filename, hf_multi)
         elif hasattr(hf_multi, "caesar_file"):

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -447,7 +447,7 @@ class TestSWIFTGalaxies:
         toysnap_filename = toysnap_withfof["toysnap_filename"]
         tp = toysnap_filename.parent
         if hf_type == "soap":
-            pytest.importorskip("compression")
+            pytest.importorskip("SOAP.compression")
             membership_filebase = tp / _toysoap_membership_filebase.name
             toysoap_filename = tp / _toysoap_filename.name
             toysoap_virtual_snapshot_filename = (


### PR DESCRIPTION
There's a new standard library module `compression` in python3.14, which the SOAP `compression` module name collided with. SOAP is being updated (https://github.com/SWIFTSIM/SOAP/pull/204) so that `compression` becomes `SOAP.compression`. Swiftgalaxy's usage of the virtual snapshot creator also becomes quite a bit simpler since it's been streamlined on the SOAP side.