### PR TITLE
Fix repeated masking

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -19,6 +19,6 @@
     "codeRepository": [
         "https://github.com/SWIFTSIM/swiftgalaxy",
     ],
-    "version": "2.5.0",
+    "version": "2.5.1",
     "license": "https://spdx.org/licenses/GPL-3.0-only.html",
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swiftgalaxy"
-version="2.5.0"
+version="2.5.1"
 authors = [
     { name="Kyle Oman", email="kyle.a.oman@durham.ac.uk" },
 ]

--- a/swiftgalaxy/demo_data.py
+++ b/swiftgalaxy/demo_data.py
@@ -551,7 +551,9 @@ class ToyHF(_HaloCatalogue):
                 The generated function that evaluates a mask.
             """
 
-            def lazy_mask() -> Union[NDArray, slice, EllipsisType]:
+            def lazy_mask(
+                active_sg: SWIFTGalaxy,
+            ) -> Union[NDArray, slice, EllipsisType]:
                 """
                 "Evaluate" a mask that selects bound particles.
 
@@ -562,14 +564,19 @@ class ToyHF(_HaloCatalogue):
                 This function must optionally mask the data (``particle_ids``) that it
                 has loaded.
 
+                Parameters
+                ----------
+                active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
+                    The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked.
+
                 Returns
                 -------
                 :class:`~numpy.ndarray`, :obj:`slice` or :obj:`Ellipsis`
                     The mask that selects bound particles.
                 """
                 getattr(
-                    getattr(sg, group_name)._particle_dataset,
-                    sg.id_particle_dataset_name,
+                    getattr(active_sg, group_name)._particle_dataset,
+                    active_sg.id_particle_dataset_name,
                 )  # load the ids
                 assert isinstance(self._mask_index, int)  # placate mypy
                 mask = {
@@ -583,11 +590,11 @@ class ToyHF(_HaloCatalogue):
                 if mask_loaded:
                     # mask the particle_ids
                     setattr(
-                        getattr(sg, group_name)._particle_dataset,
-                        f"_{sg.id_particle_dataset_name}",
+                        getattr(active_sg, group_name)._particle_dataset,
+                        f"_{active_sg.id_particle_dataset_name}",
                         getattr(
-                            getattr(sg, group_name)._particle_dataset,
-                            f"_{sg.id_particle_dataset_name}",
+                            getattr(active_sg, group_name)._particle_dataset,
+                            f"_{active_sg.id_particle_dataset_name}",
                         )[mask],
                     )
                 assert (

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -1879,7 +1879,9 @@ class Caesar(_HaloCatalogue):
                     np.concatenate(
                         [
                             np.arange(start, end)
-                            for start, end in getattr(active_sg._spatial_mask, group_name)
+                            for start, end in getattr(
+                                active_sg._spatial_mask, group_name
+                            )
                         ]
                     ),
                     mask,

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -798,9 +798,9 @@ class SOAP(_HaloCatalogue):
 
         Parameters
         ----------
-        sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
-            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` that this halo finder
-            interface is associated to.
+        sg : ~swiftgalaxy.reader.SWIFTGalaxy
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance that this halo catalogue
+            is assoiated to.
 
         mask_loaded : :obj:`bool`
             Whether to mask any data loaded while creating the mask. The iterator wants to
@@ -834,7 +834,7 @@ class SOAP(_HaloCatalogue):
                 The generated function that evaluates a mask.
             """
 
-            def lazy_mask() -> NDArray:
+            def lazy_mask(active_sg: "SWIFTGalaxy") -> NDArray:
                 """
                 Evaluate a mask that selects bound particles.
 
@@ -843,20 +843,27 @@ class SOAP(_HaloCatalogue):
 
                 This function must mask the data (``group_nr_bound``) that it has loaded.
 
+                Parameters
+                ----------
+                active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
+                    The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked.
+
                 Returns
                 -------
                 :class:`~numpy.ndarray`
                     The mask that selects bound particles.
                 """
                 mask = getattr(
-                    sg, group_name
+                    active_sg, group_name
                 )._particle_dataset.group_nr_bound.to_value(
                     u.dimensionless
                 ) == self.input_halos.halo_catalogue_index.to_value(u.dimensionless)
                 if mask_loaded:
                     # mask the group_nr_bound array that we loaded
-                    getattr(sg, group_name)._particle_dataset._group_nr_bound = getattr(
-                        sg, group_name
+                    getattr(
+                        active_sg, group_name
+                    )._particle_dataset._group_nr_bound = getattr(
+                        active_sg, group_name
                     )._particle_dataset._group_nr_bound[mask]
                 return mask
 
@@ -1207,7 +1214,7 @@ class Velociraptor(_HaloCatalogue):
                 The generated function that evaluates a mask.
             """
 
-            def lazy_mask() -> NDArray:
+            def lazy_mask(active_sg: "SWIFTGalaxy") -> NDArray:
                 """
                 Evaluate a mask that selects bound particles.
 
@@ -1215,6 +1222,11 @@ class Velociraptor(_HaloCatalogue):
                 IDs.
 
                 This function must mask the data (``particle_ids``) that it has loaded.
+
+                Parameters
+                ----------
+                active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
+                    The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked.
 
                 Returns
                 -------
@@ -1233,7 +1245,7 @@ class Velociraptor(_HaloCatalogue):
                     else 1.0
                 )
                 mask = np.isin(
-                    getattr(sg, group_name)._particle_dataset.particle_ids,
+                    getattr(active_sg, group_name)._particle_dataset.particle_ids,
                     cosmo_array(
                         particles.particle_ids,
                         comoving=False,
@@ -1243,8 +1255,10 @@ class Velociraptor(_HaloCatalogue):
                 )
                 if mask_loaded:
                     # mask the particle_ids that we loaded
-                    getattr(sg, group_name)._particle_dataset._particle_ids = getattr(
-                        sg, group_name
+                    getattr(
+                        active_sg, group_name
+                    )._particle_dataset._particle_ids = getattr(
+                        active_sg, group_name
                     )._particle_dataset._particle_ids[mask]
                 return mask
 
@@ -1836,7 +1850,7 @@ class Caesar(_HaloCatalogue):
                 The generated function that evaluates a mask.
             """
 
-            def lazy_mask() -> Union[NDArray, slice]:
+            def lazy_mask(active_sg: "SWIFTGalaxy") -> Union[NDArray, slice]:
                 """
                 Evaluate a mask that selects bound particles.
 
@@ -1844,6 +1858,11 @@ class Caesar(_HaloCatalogue):
                 read in the spatial mask.
 
                 This function must mask the data that it has loaded, but it loads nothing.
+
+                Parameters
+                ----------
+                active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
+                    The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked.
 
                 Returns
                 -------
@@ -1853,12 +1872,12 @@ class Caesar(_HaloCatalogue):
                 if not hasattr(cat, list_name):
                     return null_slice
                 mask = getattr(cat, list_name)
-                mask = mask[in_one_of_ranges(mask, getattr(sg.mask, group_name))]
+                mask = mask[in_one_of_ranges(mask, getattr(active_sg.mask, group_name))]
                 mask = np.isin(
                     np.concatenate(
                         [
                             np.arange(start, end)
-                            for start, end in getattr(sg.mask, group_name)
+                            for start, end in getattr(active_sg.mask, group_name)
                         ]
                     ),
                     mask,

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -13,9 +13,12 @@ selection of particles of different types for use with
 """
 
 from copy import deepcopy
-from typing import Optional, Union, Callable
+from typing import Optional, Union, Callable, TYPE_CHECKING
 from types import EllipsisType
 from numpy.typing import ArrayLike
+
+if TYPE_CHECKING:  # pragma: no cover
+    from swiftgalaxy import SWIFTGalaxy
 
 
 class LazyMask(object):
@@ -61,17 +64,32 @@ class LazyMask(object):
             self._evaluated = True
         return
 
-    def _evaluate(self) -> None:
-        """Force evaluation the mask function."""
+    def _evaluate(self, sg: "SWIFTGalaxy") -> None:
+        """
+        Force evaluation the mask function.
+
+        Parameters
+        ----------
+        sg : ~swiftgalaxy.reader.SWIFTGalaxy
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to pass to the ``mask_function``
+            during evaluation.
+        """
         if not self._evaluated:
             assert self._mask_function is not None  # placate mypy
-            self._mask = self._mask_function()
+            self._mask = self._mask_function(sg)
             self._evaluated = True
 
-    @property
-    def mask(self) -> Optional[Union[slice, EllipsisType, ArrayLike]]:
+    def mask(
+        self, sg: "SWIFTGalaxy"
+    ) -> Optional[Union[slice, EllipsisType, ArrayLike]]:
         """
         Get the explicitly evaluated mask, evaluating it if necessary.
+
+        Parameters
+        ----------
+        sg : ~swiftgalaxy.reader.SWIFTGalaxy
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to pass to the ``mask_function``
+            during evaluation.
 
         Returns
         -------
@@ -79,7 +97,7 @@ class LazyMask(object):
             The explicitly evaluated mask.
         """
         if not self._evaluated:
-            self._evaluate()
+            self._evaluate(sg)
         return self._mask
 
     def __copy__(self) -> "LazyMask":

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -844,7 +844,7 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
         """
         mask = getattr(self._swiftgalaxy._extra_mask, self._particle_dataset.group_name)
         if mask is not None:
-            return data[mask.mask]
+            return data[mask.mask(self._swiftgalaxy)]
         return data
 
     def _mask_dataset(self, mask: LazyMask) -> None:
@@ -869,7 +869,7 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
         # are in memory and have the old mask applied, if any:
         old_mask = getattr(self._swiftgalaxy._extra_mask, particle_name)
         if old_mask is not None:
-            old_mask._evaluate()
+            old_mask._evaluate(self._swiftgalaxy)
         # apply the new mask to any data already in memory:
         for field_name in particle_metadata.field_names:
             if self._is_namedcolumns(field_name):
@@ -884,10 +884,16 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
                         setattr(
                             getattr(self, field_name),
                             named_column,
-                            getattr(getattr(self, field_name), named_column)[mask.mask],
+                            getattr(getattr(self, field_name), named_column)[
+                                mask.mask(self._swiftgalaxy)
+                            ],
                         )
             elif getattr(self._particle_dataset, f"_{field_name}") is not None:
-                setattr(self, field_name, getattr(self, field_name)[mask.mask])
+                setattr(
+                    self,
+                    field_name,
+                    getattr(self, field_name)[mask.mask(self._swiftgalaxy)],
+                )
         # also the derived coordinates, if any:
         self._mask_derived_coordinates(mask)
         if getattr(self._swiftgalaxy._extra_mask, particle_name) is None:
@@ -908,7 +914,11 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
             setattr(
                 self._swiftgalaxy._extra_mask,
                 particle_name,
-                LazyMask(mask=np.arange(num_part, dtype=int)[old_mask.mask][mask.mask]),
+                LazyMask(
+                    mask=np.arange(num_part, dtype=int)[
+                        old_mask.mask(self._swiftgalaxy)
+                    ][mask.mask(self._swiftgalaxy)]
+                ),
             )
         return
 
@@ -1360,21 +1370,25 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
             for coord in ("r", "theta", "phi"):
                 self._spherical_coordinates[f"_{coord}"] = self._spherical_coordinates[
                     f"_{coord}"
-                ][mask.mask]
+                ][mask.mask(self._swiftgalaxy)]
         if self._spherical_velocities is not None:
             for coord in ("v_r", "v_t", "v_p"):
                 self._spherical_velocities[f"_{coord}"] = self._spherical_velocities[
                     f"_{coord}"
-                ][mask.mask]
+                ][mask.mask(self._swiftgalaxy)]
         if self._cylindrical_coordinates is not None:
             for coord in ("rho", "phi", "z"):
                 self._cylindrical_coordinates[f"_{coord}"] = (
-                    self._cylindrical_coordinates[f"_{coord}"][mask.mask]
+                    self._cylindrical_coordinates[f"_{coord}"][
+                        mask.mask(self._swiftgalaxy)
+                    ]
                 )
         if self._cylindrical_velocities is not None:
             for coord in ("v_rho", "v_phi", "v_z"):
                 self._cylindrical_velocities[f"_{coord}"] = (
-                    self._cylindrical_velocities[f"_{coord}"][mask.mask]
+                    self._cylindrical_velocities[f"_{coord}"][
+                        mask.mask(self._swiftgalaxy)
+                    ]
                 )
         return
 
@@ -1960,7 +1974,7 @@ class SWIFTGalaxy(SWIFTDataset):
                             setattr(
                                 new_named_columns_helper._named_column_dataset,
                                 f"_{named_column}",
-                                data[mask.mask],
+                                data[mask.mask(sg)],
                             )
                 else:
                     data = getattr(
@@ -1968,7 +1982,7 @@ class SWIFTGalaxy(SWIFTDataset):
                     )
                     if data is not None:
                         setattr(
-                            new_particle_dataset_helper, field_name, data[mask.mask]
+                            new_particle_dataset_helper, field_name, data[mask.mask(sg)]
                         )
             # cartesian_coordinates return a reference to coordinates on-the-fly:
             # no need to initialise here.
@@ -1976,25 +1990,29 @@ class SWIFTGalaxy(SWIFTDataset):
                 new_particle_dataset_helper._spherical_coordinates = dict()
                 for c in ("_r", "_theta", "_phi"):
                     new_particle_dataset_helper._spherical_coordinates[c] = (
-                        particle_dataset_helper._spherical_coordinates[c][mask.mask]
+                        particle_dataset_helper._spherical_coordinates[c][mask.mask(sg)]
                     )
             if particle_dataset_helper._spherical_velocities is not None:
                 new_particle_dataset_helper._spherical_velocities = dict()
                 for c in ("_v_r", "_v_t", "_v_p"):
                     new_particle_dataset_helper._spherical_velocities[c] = (
-                        particle_dataset_helper._spherical_velocities[c][mask.mask]
+                        particle_dataset_helper._spherical_velocities[c][mask.mask(sg)]
                     )
             if particle_dataset_helper._cylindrical_coordinates is not None:
                 new_particle_dataset_helper._cylindrical_coordinates = dict()
                 for c in ("_rho", "_phi", "_z"):
                     new_particle_dataset_helper._cylindrical_coordinates[c] = (
-                        particle_dataset_helper._cylindrical_coordinates[c][mask.mask]
+                        particle_dataset_helper._cylindrical_coordinates[c][
+                            mask.mask(sg)
+                        ]
                     )
             if particle_dataset_helper._cylindrical_velocities is not None:
                 new_particle_dataset_helper._cylindrical_velocities = dict()
                 for c in ("_v_rho", "_v_phi", "_v_z"):
                     new_particle_dataset_helper._cylindrical_velocities[c] = (
-                        particle_dataset_helper._cylindrical_velocities[c][mask.mask]
+                        particle_dataset_helper._cylindrical_velocities[c][
+                            mask.mask(sg)
+                        ]
                     )
         return sg
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1590,9 +1590,14 @@ def lm() -> LazyMask:
         A lazy mask.
     """
 
-    def mf() -> np.ndarray:
+    def mf(arg: None) -> np.ndarray:
         """
         Create a simple mask function.
+
+        Parameters
+        ----------
+        arg : None
+            An argument is required, but for this test object its value is unused.
 
         Returns
         -------

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -167,7 +167,7 @@ class TestCopyMaskCollection:
             stars=None,
             black_holes=np.arange(3),
             lazy_evaluated=LazyMask(mask=np.ones(100, dtype=bool)),
-            lazy_unevaluated=LazyMask(mask_function=lambda: np.s_[:20]),
+            lazy_unevaluated=LazyMask(mask_function=lambda x: np.s_[:20]),
         )
         mc_copy = deepcopy(mc)
         assert set(mc_copy.__dict__.keys()) == set(mc.__dict__.keys())
@@ -177,8 +177,8 @@ class TestCopyMaskCollection:
                 assert comparison
             else:
                 assert all(comparison)
-        assert all(mc.lazy_evaluated.mask == mc_copy.lazy_evaluated.mask)
-        assert mc.lazy_unevaluated.mask == mc_copy.lazy_unevaluated.mask
+        assert all(mc.lazy_evaluated.mask(None) == mc_copy.lazy_evaluated.mask(None))
+        assert mc.lazy_unevaluated.mask(None) == mc_copy.lazy_unevaluated.mask(None)
 
 
 class TestCopyHaloCatalogue:

--- a/tests/test_halo_catalogues.py
+++ b/tests/test_halo_catalogues.py
@@ -188,11 +188,11 @@ class TestHaloCatalogues:
         for particle_type in _present_particle_types.values():
             if expected_shape[particle_type] is not None:
                 assert (
-                    getattr(generated_extra_mask, particle_type).mask.shape
+                    getattr(generated_extra_mask, particle_type).mask(sg).shape
                     == expected_shape[particle_type]
                 )
                 assert (
-                    getattr(generated_extra_mask, particle_type).mask.sum()
+                    getattr(generated_extra_mask, particle_type).mask(sg).sum()
                     == dict(
                         gas=_n_g_1,
                         dark_matter=_n_dm_1,
@@ -230,7 +230,7 @@ class TestHaloCatalogues:
                 )
             else:
                 assert (
-                    getattr(generated_extra_mask, particle_type).mask.sum()
+                    getattr(generated_extra_mask, particle_type).mask(sg).sum()
                     == dict(gas=100, dark_matter=None, stars=100, black_holes=_n_bh_1)[
                         particle_type
                     ]
@@ -418,11 +418,11 @@ class TestHaloCataloguesMulti:
         for particle_type in _present_particle_types.values():
             if expected_shape[particle_type] is not None:
                 assert (
-                    getattr(generated_extra_mask, particle_type).mask.shape
+                    getattr(generated_extra_mask, particle_type).mask(sg).shape
                     == expected_shape[particle_type]
                 )
                 assert (
-                    getattr(generated_extra_mask, particle_type).mask.sum()
+                    getattr(generated_extra_mask, particle_type).mask(sg).sum()
                     == dict(
                         gas=_n_g_1,
                         dark_matter=_n_dm_1,
@@ -654,8 +654,8 @@ class TestVelociraptorWithSWIFTGalaxy:
             )
             for ptype in _present_particle_types.values():
                 assert np.all(
-                    getattr(sg_from_sgs._extra_mask, ptype).mask
-                    == getattr(sg._extra_mask, ptype).mask
+                    getattr(sg_from_sgs._extra_mask, ptype).mask(sg_from_sgs)
+                    == getattr(sg._extra_mask, ptype).mask(sg)
                 )
 
     def test_lazy_masking_sg(self, sg_vr):
@@ -893,14 +893,13 @@ class TestCaesarWithSWIFTGalaxy:
             )
             for ptype in _present_particle_types.values():
                 if isinstance(getattr(sg_from_sgs._extra_mask, ptype), slice):
-                    assert (
-                        getattr(sg_from_sgs._extra_mask, ptype).mask
-                        == getattr(sg._extra_mask, ptype).mask
-                    )
+                    assert getattr(sg_from_sgs._extra_mask, ptype).mask(
+                        sg_from_sgs
+                    ) == getattr(sg._extra_mask, ptype).mask(sg)
                 else:
                     assert np.all(
-                        getattr(sg_from_sgs._extra_mask, ptype).mask
-                        == getattr(sg._extra_mask, ptype).mask
+                        getattr(sg_from_sgs._extra_mask, ptype).mask(sg_from_sgs)
+                        == getattr(sg._extra_mask, ptype).mask(sg)
                     )
 
     @pytest.mark.parametrize("group_type", ["halo", "galaxy"])
@@ -926,10 +925,10 @@ class TestCaesarWithSWIFTGalaxy:
                 toysnap["toysnap_filename"],
                 Caesar(toycaesar_filename, group_type=group_type, group_index=0),
             )
-            assert sg._extra_mask.gas.mask == np.s_[:0]
-            assert sg._extra_mask.stars.mask == np.s_[:0]
-            assert sg._extra_mask.dark_matter.mask == np.s_[:0]
-            assert sg._extra_mask.black_holes.mask == np.s_[:0]
+            assert sg._extra_mask.gas.mask(sg) == np.s_[:0]
+            assert sg._extra_mask.stars.mask(sg) == np.s_[:0]
+            assert sg._extra_mask.dark_matter.mask(sg) == np.s_[:0]
+            assert sg._extra_mask.black_holes.mask(sg) == np.s_[:0]
         finally:
             _remove_toycaesar(filename=toycaesar_filename)
 
@@ -1359,8 +1358,8 @@ class TestSOAPWithSWIFTGalaxy:
             )
             for ptype in _present_particle_types.values():
                 assert np.all(
-                    getattr(sg_from_sgs._extra_mask, ptype).mask
-                    == getattr(sg._extra_mask, ptype).mask
+                    getattr(sg_from_sgs._extra_mask, ptype).mask(sg_from_sgs)
+                    == getattr(sg._extra_mask, ptype).mask(sg)
                 )
 
     def test_lazy_masking_sg(self, sg_soap):

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -239,8 +239,8 @@ class TestSWIFTGalaxies:
             )
             for ptype in _present_particle_types.values():
                 assert np.all(
-                    getattr(sg_from_sgs._extra_mask, ptype).mask
-                    == getattr(sg._extra_mask, ptype).mask
+                    getattr(sg_from_sgs._extra_mask, ptype).mask(sg_from_sgs)
+                    == getattr(sg._extra_mask, ptype).mask(sg)
                 )
             count += 1
         assert count == len(sgs.halo_catalogue.index)

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -3,7 +3,9 @@
 import pytest
 from copy import copy, deepcopy
 import numpy as np
+import unyt as u
 from unyt.testing import assert_allclose_units
+from swiftsimio import cosmo_quantity
 from swiftgalaxy import SWIFTGalaxy, MaskCollection
 from swiftgalaxy.demo_data import (
     ToyHF,
@@ -136,6 +138,60 @@ class TestMaskingSWIFTGalaxy:
             assert sg.gas.masses.size == 100
         finally:
             _remove_toysnap(snapfile=toysnap_filename)
+
+    def test_repeated_copy_mask(self, sg_soap):
+        """
+        Check that we can apply a copying mask operation more than once.
+
+        Regression test for https://github.com/SWIFTSIM/swiftgalaxy/issues/89.
+        This had previously caused an ``IndexError``, specifically when using a
+        :class:`~swiftgalaxy.halo_catalogues.SOAP` catalogue (because it uses a boolean
+        ``"bound_only"`` mask).
+        """
+        sg_copy1 = sg_soap[
+            MaskCollection(
+                gas=sg_soap.gas.spherical_coordinates.r
+                < cosmo_quantity(
+                    3,
+                    u.kpc,
+                    comoving=True,
+                    scale_factor=sg_soap.metadata.scale_factor,
+                    scale_exponent=1,
+                )
+            )
+        ]
+        sg_copy2 = sg_soap[
+            MaskCollection(
+                gas=sg_soap.gas.spherical_coordinates.r
+                < cosmo_quantity(
+                    2,
+                    u.kpc,
+                    comoving=True,
+                    scale_factor=sg_soap.metadata.scale_factor,
+                    scale_exponent=1,
+                )
+            )
+        ]
+        assert (
+            sg_copy1.gas.spherical_coordinates.r
+            < cosmo_quantity(
+                3,
+                u.kpc,
+                comoving=True,
+                scale_factor=sg_soap.metadata.scale_factor,
+                scale_exponent=1,
+            )
+        ).all()
+        assert (
+            sg_copy2.gas.spherical_coordinates.r
+            < cosmo_quantity(
+                2,
+                u.kpc,
+                comoving=True,
+                scale_factor=sg_soap.metadata.scale_factor,
+                scale_exponent=1,
+            )
+        ).all()
 
 
 class TestMaskingParticleDatasets:

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -359,25 +359,25 @@ class TestLazyMask:
         """Check that accessing mask triggers evaluation if lazy."""
         assert lm._evaluated is False
         assert not hasattr(lm, "_mask")
-        assert (lm.mask == lm._mask_function()).all()
+        assert (lm.mask(None) == lm._mask_function(None)).all()
         assert lm._evaluated
-        assert (lm._mask == lm._mask_function()).all()
+        assert (lm._mask == lm._mask_function(None)).all()
 
     def test_access_not_lazy(self):
         """Check that accessing the mask works for a non-lazy mask."""
         m = np.ones(10, dtype=bool)
         lm = LazyMask(mask=m)
         assert lm._evaluated
-        assert (lm.mask == m).all()
+        assert (lm.mask(None) == m).all()
 
     def test_manual_trigger_eval(self, lm):
         """Check that accessing mask triggers evaluation if lazy."""
         assert lm._evaluated is False
         assert not hasattr(lm, "_mask")
-        lm._evaluate()
+        lm._evaluate(None)
         assert lm._evaluated
-        assert (lm.mask == lm._mask_function()).all()
-        assert (lm._mask == lm._mask_function()).all()
+        assert (lm.mask(None) == lm._mask_function(None)).all()
+        assert (lm._mask == lm._mask_function(None)).all()
 
     def test_trigger_eval_once_only(self):
         """Check that we can't trigger mask evaluation repeatedly."""
@@ -387,9 +387,14 @@ class TestLazyMask:
 
             call_counter: int = 0
 
-            def __call__(self):
+            def __call__(self, arg: None):
                 """
                 Call the class to behave like a simple mask function.
+
+                Parameters
+                ----------
+                arg : None
+                    An argument is required but its value is unused.
 
                 Returns
                 -------
@@ -403,12 +408,12 @@ class TestLazyMask:
         lm = LazyMask(mask_function=mf)
         assert lm._evaluated is False
         # trigger a mask evaluation:
-        lm.mask
+        lm.mask(None)
         assert lm._evaluated is True
         assert mf.call_counter == 1
         # we shouldn't be able to trigger or force another mask evaluation:
-        lm.mask
-        lm._evaluate()
+        lm.mask(None)
+        lm._evaluate(None)
         assert mf.call_counter == 1
 
     def test_copy(self, lm):
@@ -419,12 +424,12 @@ class TestLazyMask:
         assert not hasattr(lm_unevaluated_copy, "_mask")
         assert lm_unevaluated_copy._mask_function is lm._mask_function
         # trigger evaluated
-        lm._evaluate()
+        lm._evaluate(None)
         assert lm._evaluated
         # now copy after evaluating
         lm_evaluated_copy = copy(lm)
         assert lm_evaluated_copy._evaluated
-        assert (lm_evaluated_copy._mask == lm._mask_function()).all()
+        assert (lm_evaluated_copy._mask == lm._mask_function(None)).all()
         assert lm_evaluated_copy._mask_function is lm._mask_function
         # and test a non-lazy mask
         m = np.ones(10, dtype=bool)
@@ -442,12 +447,12 @@ class TestLazyMask:
         assert not hasattr(lm_unevaluated_copy, "_mask")
         assert lm_unevaluated_copy._mask_function is lm._mask_function
         # trigger evaluated
-        lm._evaluate()
+        lm._evaluate(None)
         assert lm._evaluated
         # now copy after evaluating
         lm_evaluated_copy = deepcopy(lm)
         assert lm_evaluated_copy._evaluated
-        assert (lm_evaluated_copy._mask == lm._mask_function()).all()
+        assert (lm_evaluated_copy._mask == lm._mask_function(None)).all()
         assert lm_evaluated_copy._mask_function is lm._mask_function
         # and test a non-lazy mask
         m = np.ones(10, dtype=bool)
@@ -464,8 +469,8 @@ class TestLazyMask:
             ValueError, match="Cannot compare when one or more masks are not evaluated."
         ):
             lm == lm2
-        lm._evaluate()
-        lm2._evaluate()
+        lm._evaluate(None)
+        lm2._evaluate(None)
         assert lm == lm2
         lmn = LazyMask(mask=None)
         assert lm != lmn
@@ -477,7 +482,7 @@ class TestLazyMask:
             ValueError, match="Cannot compare when one or more masks are not evaluated."
         ):
             lm == m
-        lm._evaluate()
+        lm._evaluate(None)
         assert lm == m
         assert lm != np.zeros(10, dtype=bool)
 


### PR DESCRIPTION
There could be quite confusing indirection when unevaluated `LazyMask` objects got copied to new `SWIFTGalaxy` objects with e.g. `sg[...]`. The `LazyMask` would retain a reference to the original `SWIFTGalaxy` which could lead to evaluating the mask using incorrect data.

At the cost of now requiring an argument to `LazyMask.evaluate` and `LazyMask.mask` becoming a 1-argument function instead of a `@property`, a reference to the relevant `SWIFTGalaxy` is now available at mask evaluation time which should avoid this kind of issue.

Closes #89 