### PR TITLE
Delay mask evaluation more

### DIFF
--- a/swiftgalaxy/demo_data.py
+++ b/swiftgalaxy/demo_data.py
@@ -597,7 +597,7 @@ class ToyHF(_HaloCatalogue):
                 )  # placate mypy
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, sg=sg)
+            return LazyMask(mask_function=lazy_mask, sg=sg, mask_type=group_name)
 
         return MaskCollection(
             **{

--- a/swiftgalaxy/demo_data.py
+++ b/swiftgalaxy/demo_data.py
@@ -597,7 +597,7 @@ class ToyHF(_HaloCatalogue):
                 )  # placate mypy
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, sg=sg, mask_type=group_name)
+            return LazyMask(mask_function=lazy_mask, mask_type=group_name)
 
         return MaskCollection(
             **{

--- a/swiftgalaxy/demo_data.py
+++ b/swiftgalaxy/demo_data.py
@@ -551,9 +551,7 @@ class ToyHF(_HaloCatalogue):
                 The generated function that evaluates a mask.
             """
 
-            def lazy_mask(
-                active_sg: SWIFTGalaxy,
-            ) -> Union[NDArray, slice, EllipsisType]:
+            def lazy_mask() -> Union[NDArray, slice, EllipsisType]:
                 """
                 "Evaluate" a mask that selects bound particles.
 
@@ -564,19 +562,14 @@ class ToyHF(_HaloCatalogue):
                 This function must optionally mask the data (``particle_ids``) that it
                 has loaded.
 
-                Parameters
-                ----------
-                active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
-                    The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked.
-
                 Returns
                 -------
                 :class:`~numpy.ndarray`, :obj:`slice` or :obj:`Ellipsis`
                     The mask that selects bound particles.
                 """
                 getattr(
-                    getattr(active_sg, group_name)._particle_dataset,
-                    active_sg.id_particle_dataset_name,
+                    getattr(sg, group_name)._particle_dataset,
+                    sg.id_particle_dataset_name,
                 )  # load the ids
                 assert isinstance(self._mask_index, int)  # placate mypy
                 mask = {
@@ -590,11 +583,11 @@ class ToyHF(_HaloCatalogue):
                 if mask_loaded:
                     # mask the particle_ids
                     setattr(
-                        getattr(active_sg, group_name)._particle_dataset,
-                        f"_{active_sg.id_particle_dataset_name}",
+                        getattr(sg, group_name)._particle_dataset,
+                        f"_{sg.id_particle_dataset_name}",
                         getattr(
-                            getattr(active_sg, group_name)._particle_dataset,
-                            f"_{active_sg.id_particle_dataset_name}",
+                            getattr(sg, group_name)._particle_dataset,
+                            f"_{sg.id_particle_dataset_name}",
                         )[mask],
                     )
                 assert (

--- a/swiftgalaxy/demo_data.py
+++ b/swiftgalaxy/demo_data.py
@@ -604,7 +604,7 @@ class ToyHF(_HaloCatalogue):
                 )  # placate mypy
                 return mask
 
-            return LazyMask(mask_function=lazy_mask)
+            return LazyMask(mask_function=lazy_mask, sg=sg)
 
         return MaskCollection(
             **{

--- a/swiftgalaxy/demo_data.py
+++ b/swiftgalaxy/demo_data.py
@@ -597,7 +597,7 @@ class ToyHF(_HaloCatalogue):
                 )  # placate mypy
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, mask_type=group_name)
+            return LazyMask(mask_function=lazy_mask)
 
         return MaskCollection(
             **{

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -867,7 +867,7 @@ class SOAP(_HaloCatalogue):
                     )._particle_dataset._group_nr_bound[mask]
                 return mask
 
-            return LazyMask(mask_function=lazy_mask)
+            return LazyMask(mask_function=lazy_mask, sg=sg)
 
         return MaskCollection(
             **{
@@ -1262,7 +1262,7 @@ class Velociraptor(_HaloCatalogue):
                     )._particle_dataset._particle_ids[mask]
                 return mask
 
-            return LazyMask(mask_function=lazy_mask)
+            return LazyMask(mask_function=lazy_mask, sg=sg)
 
         return MaskCollection(
             **{
@@ -1888,7 +1888,7 @@ class Caesar(_HaloCatalogue):
                 )
                 return mask
 
-            return LazyMask(mask_function=lazy_mask)
+            return LazyMask(mask_function=lazy_mask, sg=sg)
 
         return MaskCollection(
             **{

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -293,18 +293,24 @@ class _HaloCatalogue(ABC):
                 raise RuntimeError(
                     "Halo catalogue has multiple galaxies and is not currently masked."
                 )
-            return self._generate_bound_only_mask(sg, mask_loaded=mask_loaded)
+            mask_collection = self._generate_bound_only_mask(
+                sg, mask_loaded=mask_loaded
+            )
         elif self.extra_mask is None:
-            return MaskCollection(**{k: None for k in sg.metadata.present_group_names})
+            mask_collection = MaskCollection(
+                **{k: Ellipsis for k in sg.metadata.present_group_names}
+            )
         else:
             # Keep user provided mask. If no mask provided for a particle type
             # use None (no mask).
-            return MaskCollection(
+            mask_collection = MaskCollection(
                 **{
                     name: getattr(self.extra_mask, name, None)
                     for name in sg.metadata.present_group_names
                 }
             )
+        mask_collection._update_sg(sg)
+        return mask_collection
 
     @property
     def _mask_index(self) -> Optional[Union[int, list[int]]]:
@@ -860,7 +866,9 @@ class SOAP(_HaloCatalogue):
                     )._particle_dataset._group_nr_bound[mask]
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, sg=sg, combinable=False)
+            return LazyMask(
+                mask_function=lazy_mask, sg=sg, combinable=False, mask_type=group_name
+            )
 
         return MaskCollection(
             **{
@@ -1248,7 +1256,9 @@ class Velociraptor(_HaloCatalogue):
                     )._particle_dataset._particle_ids[mask]
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, sg=sg, combinable=False)
+            return LazyMask(
+                mask_function=lazy_mask, sg=sg, combinable=False, mask_type=group_name
+            )
 
         return MaskCollection(
             **{
@@ -1867,7 +1877,9 @@ class Caesar(_HaloCatalogue):
                 )
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, sg=sg, combinable=False)
+            return LazyMask(
+                mask_function=lazy_mask, sg=sg, combinable=False, mask_type=group_name
+            )
 
         return MaskCollection(
             **{

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -293,27 +293,15 @@ class _HaloCatalogue(ABC):
                 raise RuntimeError(
                     "Halo catalogue has multiple galaxies and is not currently masked."
                 )
-            mask_collection = self._generate_bound_only_mask(
-                sg, mask_loaded=mask_loaded
-            )
+            return self._generate_bound_only_mask(sg, mask_loaded=mask_loaded)
         elif self.extra_mask is None:
-            mask_collection = MaskCollection(
-                **{k: LazyMask(mask=Ellipsis) for k in sg.metadata.present_group_names}
+            return MaskCollection._blank_from_mask_types(
+                sg.metadata.present_group_names
             )
         else:
-            # Keep user provided mask. If no mask provided for a particle type
-            # use Ellipsis (no mask).
-            mask_collection = MaskCollection(
-                **{
-                    name: mask
-                    if isinstance(
-                        mask := getattr(self.extra_mask, name, Ellipsis), LazyMask
-                    )
-                    else LazyMask(mask=mask)
-                    for name in sg.metadata.present_group_names
-                }
-            )
-        return mask_collection
+            # Keep user provided mask.
+            assert isinstance(self.extra_mask, MaskCollection)  # placate mypy
+            return self.extra_mask
 
     @property
     def _mask_index(self) -> Optional[Union[int, list[int]]]:
@@ -869,7 +857,7 @@ class SOAP(_HaloCatalogue):
                     )._particle_dataset._group_nr_bound[mask]
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, combinable=False)
+            return LazyMask(mask_function=lazy_mask)
 
         return MaskCollection(
             **{
@@ -1257,7 +1245,7 @@ class Velociraptor(_HaloCatalogue):
                     )._particle_dataset._particle_ids[mask]
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, combinable=False)
+            return LazyMask(mask_function=lazy_mask)
 
         return MaskCollection(
             **{
@@ -1876,7 +1864,7 @@ class Caesar(_HaloCatalogue):
                 )
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, combinable=False)
+            return LazyMask(mask_function=lazy_mask)
 
         return MaskCollection(
             **{

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -867,7 +867,7 @@ class SOAP(_HaloCatalogue):
                     )._particle_dataset._group_nr_bound[mask]
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, sg=sg)
+            return LazyMask(mask_function=lazy_mask, sg=sg, combinable=False)
 
         return MaskCollection(
             **{
@@ -1262,7 +1262,7 @@ class Velociraptor(_HaloCatalogue):
                     )._particle_dataset._particle_ids[mask]
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, sg=sg)
+            return LazyMask(mask_function=lazy_mask, sg=sg, combinable=False)
 
         return MaskCollection(
             **{
@@ -1888,7 +1888,7 @@ class Caesar(_HaloCatalogue):
                 )
                 return mask
 
-            return LazyMask(mask_function=lazy_mask, sg=sg)
+            return LazyMask(mask_function=lazy_mask, sg=sg, combinable=False)
 
         return MaskCollection(
             **{

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -834,7 +834,7 @@ class SOAP(_HaloCatalogue):
                 The generated function that evaluates a mask.
             """
 
-            def lazy_mask(active_sg: "SWIFTGalaxy") -> NDArray:
+            def lazy_mask() -> NDArray:
                 """
                 Evaluate a mask that selects bound particles.
 
@@ -843,27 +843,20 @@ class SOAP(_HaloCatalogue):
 
                 This function must mask the data (``group_nr_bound``) that it has loaded.
 
-                Parameters
-                ----------
-                active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
-                    The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked.
-
                 Returns
                 -------
                 :class:`~numpy.ndarray`
                     The mask that selects bound particles.
                 """
                 mask = getattr(
-                    active_sg, group_name
+                    sg, group_name
                 )._particle_dataset.group_nr_bound.to_value(
                     u.dimensionless
                 ) == self.input_halos.halo_catalogue_index.to_value(u.dimensionless)
                 if mask_loaded:
                     # mask the group_nr_bound array that we loaded
-                    getattr(
-                        active_sg, group_name
-                    )._particle_dataset._group_nr_bound = getattr(
-                        active_sg, group_name
+                    getattr(sg, group_name)._particle_dataset._group_nr_bound = getattr(
+                        sg, group_name
                     )._particle_dataset._group_nr_bound[mask]
                 return mask
 
@@ -1214,7 +1207,7 @@ class Velociraptor(_HaloCatalogue):
                 The generated function that evaluates a mask.
             """
 
-            def lazy_mask(active_sg: "SWIFTGalaxy") -> NDArray:
+            def lazy_mask() -> NDArray:
                 """
                 Evaluate a mask that selects bound particles.
 
@@ -1222,11 +1215,6 @@ class Velociraptor(_HaloCatalogue):
                 IDs.
 
                 This function must mask the data (``particle_ids``) that it has loaded.
-
-                Parameters
-                ----------
-                active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
-                    The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked.
 
                 Returns
                 -------
@@ -1245,7 +1233,7 @@ class Velociraptor(_HaloCatalogue):
                     else 1.0
                 )
                 mask = np.isin(
-                    getattr(active_sg, group_name)._particle_dataset.particle_ids,
+                    getattr(sg, group_name)._particle_dataset.particle_ids,
                     cosmo_array(
                         particles.particle_ids,
                         comoving=False,
@@ -1255,10 +1243,8 @@ class Velociraptor(_HaloCatalogue):
                 )
                 if mask_loaded:
                     # mask the particle_ids that we loaded
-                    getattr(
-                        active_sg, group_name
-                    )._particle_dataset._particle_ids = getattr(
-                        active_sg, group_name
+                    getattr(sg, group_name)._particle_dataset._particle_ids = getattr(
+                        sg, group_name
                     )._particle_dataset._particle_ids[mask]
                 return mask
 
@@ -1850,7 +1836,7 @@ class Caesar(_HaloCatalogue):
                 The generated function that evaluates a mask.
             """
 
-            def lazy_mask(active_sg: "SWIFTGalaxy") -> Union[NDArray, slice]:
+            def lazy_mask() -> Union[NDArray, slice]:
                 """
                 Evaluate a mask that selects bound particles.
 
@@ -1858,11 +1844,6 @@ class Caesar(_HaloCatalogue):
                 read in the spatial mask.
 
                 This function must mask the data that it has loaded, but it loads nothing.
-
-                Parameters
-                ----------
-                active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
-                    The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked.
 
                 Returns
                 -------
@@ -1873,15 +1854,13 @@ class Caesar(_HaloCatalogue):
                     return null_slice
                 mask = getattr(cat, list_name)
                 mask = mask[
-                    in_one_of_ranges(mask, getattr(active_sg._spatial_mask, group_name))
+                    in_one_of_ranges(mask, getattr(sg._spatial_mask, group_name))
                 ]
                 mask = np.isin(
                     np.concatenate(
                         [
                             np.arange(start, end)
-                            for start, end in getattr(
-                                active_sg._spatial_mask, group_name
-                            )
+                            for start, end in getattr(sg._spatial_mask, group_name)
                         ]
                     ),
                     mask,

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -298,21 +298,18 @@ class _HaloCatalogue(ABC):
             )
         elif self.extra_mask is None:
             mask_collection = MaskCollection(
-                **{
-                    k: LazyMask(mask=Ellipsis, mask_type=k)
-                    for k in sg.metadata.present_group_names
-                }
+                **{k: LazyMask(mask=Ellipsis) for k in sg.metadata.present_group_names}
             )
         else:
             # Keep user provided mask. If no mask provided for a particle type
-            # use None (no mask).
+            # use Ellipsis (no mask).
             mask_collection = MaskCollection(
                 **{
                     name: mask
                     if isinstance(
                         mask := getattr(self.extra_mask, name, Ellipsis), LazyMask
                     )
-                    else LazyMask(mask=mask, mask_type=name)
+                    else LazyMask(mask=mask)
                     for name in sg.metadata.present_group_names
                 }
             )
@@ -872,9 +869,7 @@ class SOAP(_HaloCatalogue):
                     )._particle_dataset._group_nr_bound[mask]
                 return mask
 
-            return LazyMask(
-                mask_function=lazy_mask, combinable=False, mask_type=group_name
-            )
+            return LazyMask(mask_function=lazy_mask, combinable=False)
 
         return MaskCollection(
             **{
@@ -1262,9 +1257,7 @@ class Velociraptor(_HaloCatalogue):
                     )._particle_dataset._particle_ids[mask]
                 return mask
 
-            return LazyMask(
-                mask_function=lazy_mask, combinable=False, mask_type=group_name
-            )
+            return LazyMask(mask_function=lazy_mask, combinable=False)
 
         return MaskCollection(
             **{
@@ -1883,9 +1876,7 @@ class Caesar(_HaloCatalogue):
                 )
                 return mask
 
-            return LazyMask(
-                mask_function=lazy_mask, combinable=False, mask_type=group_name
-            )
+            return LazyMask(mask_function=lazy_mask, combinable=False)
 
         return MaskCollection(
             **{

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -299,7 +299,7 @@ class _HaloCatalogue(ABC):
         elif self.extra_mask is None:
             mask_collection = MaskCollection(
                 **{
-                    k: LazyMask(mask=Ellipsis, sg=sg, mask_type=k)
+                    k: LazyMask(mask=Ellipsis, mask_type=k)
                     for k in sg.metadata.present_group_names
                 }
             )
@@ -312,7 +312,7 @@ class _HaloCatalogue(ABC):
                     if isinstance(
                         mask := getattr(self.extra_mask, name, Ellipsis), LazyMask
                     )
-                    else LazyMask(mask=mask, sg=sg, mask_type=name)
+                    else LazyMask(mask=mask, mask_type=name)
                     for name in sg.metadata.present_group_names
                 }
             )
@@ -873,7 +873,7 @@ class SOAP(_HaloCatalogue):
                 return mask
 
             return LazyMask(
-                mask_function=lazy_mask, sg=sg, combinable=False, mask_type=group_name
+                mask_function=lazy_mask, combinable=False, mask_type=group_name
             )
 
         return MaskCollection(
@@ -1263,7 +1263,7 @@ class Velociraptor(_HaloCatalogue):
                 return mask
 
             return LazyMask(
-                mask_function=lazy_mask, sg=sg, combinable=False, mask_type=group_name
+                mask_function=lazy_mask, combinable=False, mask_type=group_name
             )
 
         return MaskCollection(
@@ -1884,7 +1884,7 @@ class Caesar(_HaloCatalogue):
                 return mask
 
             return LazyMask(
-                mask_function=lazy_mask, sg=sg, combinable=False, mask_type=group_name
+                mask_function=lazy_mask, combinable=False, mask_type=group_name
             )
 
         return MaskCollection(

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -298,18 +298,24 @@ class _HaloCatalogue(ABC):
             )
         elif self.extra_mask is None:
             mask_collection = MaskCollection(
-                **{k: Ellipsis for k in sg.metadata.present_group_names}
+                **{
+                    k: LazyMask(mask=Ellipsis, sg=sg, mask_type=k)
+                    for k in sg.metadata.present_group_names
+                }
             )
         else:
             # Keep user provided mask. If no mask provided for a particle type
             # use None (no mask).
             mask_collection = MaskCollection(
                 **{
-                    name: getattr(self.extra_mask, name, None)
+                    name: mask
+                    if isinstance(
+                        mask := getattr(self.extra_mask, name, Ellipsis), LazyMask
+                    )
+                    else LazyMask(mask=mask, sg=sg, mask_type=name)
                     for name in sg.metadata.present_group_names
                 }
             )
-        mask_collection._update_sg(sg)
         return mask_collection
 
     @property

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -15,10 +15,13 @@ selection of particles of different types for use with
 from copy import deepcopy
 from typing import Optional, Union, Callable, TYPE_CHECKING
 from types import EllipsisType
-from numpy.typing import ArrayLike
+import numpy as np
+from numpy.typing import NDArray
 
 if TYPE_CHECKING:  # pragma: no cover
     from swiftgalaxy import SWIFTGalaxy
+
+MaskType = Optional[Union[slice, EllipsisType, NDArray]]
 
 
 class LazyMask(object):
@@ -49,13 +52,13 @@ class LazyMask(object):
     """
 
     _mask_function: Optional[Callable]
-    _mask: Optional[Union[slice, EllipsisType, ArrayLike]]
+    _mask: MaskType
     _evaluated: bool
     _sg: "Optional[SWIFTGalaxy]"
 
     def __init__(
         self,
-        mask: Optional[Union[slice, EllipsisType, ArrayLike]] = None,
+        mask: MaskType = None,
         mask_function: Optional[Callable] = None,
         sg: "Optional[SWIFTGalaxy]" = None,
     ) -> None:
@@ -81,7 +84,7 @@ class LazyMask(object):
             self._evaluated = True
 
     @property
-    def mask(self) -> Optional[Union[slice, EllipsisType, ArrayLike]]:
+    def mask(self) -> MaskType:
         """
         Get the explicitly evaluated mask, evaluating it if necessary.
 
@@ -271,7 +274,7 @@ class MaskCollection(object):
 
     def __init__(
         self,
-        **kwargs: Optional[Union[slice, EllipsisType, ArrayLike, LazyMask]],
+        **kwargs: Optional[Union[MaskType, LazyMask]],
     ) -> None:
         for k, v in kwargs.items():
             if isinstance(v, LazyMask):
@@ -350,3 +353,110 @@ class MaskCollection(object):
         for v in self.__dict__.values():
             if isinstance(v, LazyMask):
                 v._update_sg(sg)
+
+    def combine(self, other_mask_collection: "MaskCollection") -> "MaskCollection":
+        """
+        Combine this :class:`~swiftgalaxy.masks.MaskCollection` with another.
+
+        ``data[this_mask.<type>.mask][other_mask.<type>.mask]`` and
+        ``data[combined_mask.<type>.mask]`` are equivalent, where
+        ``combined_mask = this_mask.combine(other_mask)``.
+
+        Parameters
+        ----------
+        other_mask_collection : ~swiftgalaxy.masks.MaskCollection
+            The other mask collection to combine with this one.
+        """
+        return_collection = {}
+        all_keys = set(self.__dict__.keys()) | set(
+            other_mask_collection.__dict__.keys()
+        )
+        for k in all_keys:
+            if not (
+                isinstance(getattr(self, k), LazyMask)
+                or isinstance(getattr(other_mask_collection, k), LazyMask)
+            ):
+                # this is not a mask field, skip
+                continue
+            elif isinstance(getattr(self, k), LazyMask) and isinstance(
+                getattr(other_mask_collection, k), LazyMask
+            ):
+                # both are masks, combine
+                this_mask = getattr(self, k)
+                other_mask = getattr(other_mask_collection, k)
+                return_collection[k] = _combine_lazy_masks(
+                    this_mask, other_mask, mask_type=k
+                )
+            else:
+                # one xor other is mask, assign
+                if isinstance(getattr(self, k), LazyMask):
+                    return_collection[k] = getattr(self, k)
+                else:  # isinstance(getattr(other_mask_collection, k), LazyMask)
+                    return_collection[k] = getattr(other_mask_collection, k)
+        return MaskCollection(**return_collection)
+
+
+def _combine_lazy_masks(
+    first_mask: LazyMask, second_mask: LazyMask, mask_type: str
+) -> LazyMask:
+    """
+    Combine two lazy masks into one, avoiding evaluating them.
+
+    Parameters
+    ----------
+    first_mask : ~swiftgalaxy.masks.LazyMask
+        The first mask to combine.
+
+    second_mask : ~swiftgalaxy.masks.LazyMask
+        The second mask to combine.
+
+    mask_type : str
+        The particle type that this mask applies to.
+
+    Returns
+    -------
+    ~swiftgalaxy.masks.LazyMask
+        The combined mask.
+    """
+    if first_mask._sg is not None and second_mask._sg is not None:
+        assert first_mask._sg is second_mask._sg, (
+            "Masks must be for same SWIFTGalaxy to be combined."
+        )
+        sg = first_mask._sg
+    elif first_mask._sg is not None:
+        sg = first_mask._sg
+    elif second_mask._sg is not None:
+        sg = second_mask._sg
+    else:
+        sg = None
+
+    # may as well always defer evaluating combination until it's asked for
+    def lazy_mask(active_sg: "SWIFTGalaxy") -> NDArray:
+        """
+        Evaluate a mask combining two existing masks.
+
+        Parameters
+        ----------
+        active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked.
+
+        Returns
+        -------
+        :class:`~numpy.ndarray`
+            The combined mask.
+        """
+        # need to convert to an integer mask to combine
+        # (boolean is insufficient in case of re-ordering masks)
+        if sg is None:
+            num_part = getattr(active_sg.metadata, f"n_{mask_type}")
+        elif sg._spatial_mask is None:
+            # get a count of particles in the box
+            num_part = getattr(sg.metadata, f"n_{mask_type}")
+        else:  # sg._spatial_mask is not None
+            # get a count of particles in the spatial mask region
+            num_part = np.sum(
+                sg._spatial_mask.get_masked_counts_offsets()[0][mask_type]
+            )
+        return np.arange(num_part)[first_mask.mask][second_mask.mask]
+
+    return LazyMask(mask_function=lazy_mask, sg=sg)

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -432,7 +432,7 @@ class MaskCollection(object):
             return self._masks[attr]
         except KeyError:
             raise AttributeError(
-                f"Attribute {attr} not found (and not a key of `_masks`)"
+                f"'MaskCollection' has no attribute '{attr}' (and not a key of `_masks`)"
             )
 
     def __copy__(self) -> "MaskCollection":

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -48,16 +48,11 @@ class LazyMask(object):
         If ``True``, it declares that for this mask ``data[this_mask][other_mask]`` is
         equivalent to ``data[this_mask[other_mask]]``. This usually means that it is an
         array of integer indices to select from ``data``.
-
-    mask_type : str, default: ``None``
-        The :mod:`swiftsimio` "group_type" (e.g. ``"gas"``, ``"dark_matter"``, etc.) that
-        this mask applies to.
     """
 
     _mask_function: Optional[Callable]
     _mask: MaskType
     _evaluated: bool
-    _mask_type: "Optional[str]"
     _combinable: bool
 
     def __init__(
@@ -65,7 +60,6 @@ class LazyMask(object):
         mask: MaskType = None,
         mask_function: Optional[Callable] = None,
         combinable: bool = False,
-        mask_type: Optional[str] = None,
     ) -> None:
         if mask_function is None and mask is None:
             self._mask = None
@@ -78,7 +72,6 @@ class LazyMask(object):
             self._mask = mask
             self._mask_function = mask_function
             self._evaluated = True
-        self._mask_type = mask_type
         self._combinable = combinable
         return
 
@@ -89,7 +82,7 @@ class LazyMask(object):
             self._mask = self._mask_function()
             self._evaluated = True
 
-    def _make_combinable(self, sg: "SWIFTGalaxy") -> None:
+    def _make_combinable(self, *, sg: "SWIFTGalaxy", mask_type: str) -> None:
         """
         Ensure that the mask can have an arbitrary second mask applied to combine them.
 
@@ -101,16 +94,20 @@ class LazyMask(object):
         sg : ~swiftgalaxy.reader.SWIFTGalaxy
             The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to use to look up particle count
             metadata.
+
+        mask_type : str
+            The :mod:`swiftsimio` group name that this mask is for (e.g. ``"gas"``,
+            ``"dark_matter"``, etc.), used to look up particle count metadata.
         """
         # need to convert to an integer mask to combine
         # (boolean is insufficient in case of re-ordering masks)
         if sg._spatial_mask is None:
             # get a count of particles in the box
-            num_part = getattr(sg.metadata, f"n_{self._mask_type}")
+            num_part = getattr(sg.metadata, f"n_{mask_type}")
         else:  # sg._spatial_mask is not None
             # get a count of particles in the spatial mask region
             num_part = np.sum(
-                sg._spatial_mask.get_masked_counts_offsets()[0][self._mask_type]
+                sg._spatial_mask.get_masked_counts_offsets()[0][mask_type]
             )
         if self._mask_function is not None:
             old_mask_function = self._mask_function  # need reference to the current one
@@ -120,7 +117,7 @@ class LazyMask(object):
         self._combinable = True
 
     def _combined_with(
-        self, other_mask: "LazyMask", *, sg: "SWIFTGalaxy"
+        self, other_mask: "LazyMask", *, sg: "SWIFTGalaxy", mask_type: str
     ) -> "LazyMask":
         """
         Combine two lazy masks into one, avoiding evaluating them.
@@ -137,6 +134,10 @@ class LazyMask(object):
         sg : ~swiftgalaxy.reader.SWIFTGalaxy
             The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to use to look up particle count
             metadata.
+
+        mask_type : str
+            The :mod:`swiftsimio` group name that this mask is for (e.g. ``"gas"``,
+            ``"dark_matter"``, etc.), used to look up particle count metadata.
 
         Returns
         -------
@@ -155,7 +156,7 @@ class LazyMask(object):
                 The combined mask.
             """
             if not self._combinable:
-                self._make_combinable(sg)
+                self._make_combinable(sg=sg, mask_type=mask_type)
             assert isinstance(self.mask, np.ndarray)  # placate mypy
             assert self.mask.dtype == int
             return self.mask[other_mask.mask]
@@ -163,7 +164,6 @@ class LazyMask(object):
         return LazyMask(
             mask_function=lazy_mask,
             combinable=True,
-            mask_type=self._mask_type,
         )
 
     @property
@@ -196,13 +196,11 @@ class LazyMask(object):
                 mask=self._mask,
                 mask_function=self._mask_function,
                 combinable=self._combinable,
-                mask_type=self._mask_type,
             )
         else:
             return LazyMask(
                 mask_function=self._mask_function,
                 combinable=self._combinable,
-                mask_type=self._mask_type,
             )
 
     def __deepcopy__(self, memo: Optional[dict] = None) -> "LazyMask":
@@ -227,13 +225,11 @@ class LazyMask(object):
                 mask=deepcopy(self._mask),
                 mask_function=deepcopy(self._mask_function),
                 combinable=deepcopy(self._combinable),
-                mask_type=deepcopy(self._mask_type),
             )
         else:
             return LazyMask(
                 mask_function=deepcopy(self._mask_function),
                 combinable=deepcopy(self._combinable),
-                mask_type=deepcopy(self._mask_type),
             )
 
     def __eq__(self, other: object) -> bool:
@@ -362,14 +358,10 @@ class MaskCollection(object):
         for k, v in kwargs.items():
             if isinstance(v, LazyMask):
                 self._masks[k] = v
-                assert getattr(self, k)._mask_type == k, (
-                    f"`LazyMask` for {k} has non-matching "
-                    f"`mask_type` {getattr(self, k)._mark_type}."
-                )
-            elif v is None:  # a literal `None` mask would resolve like `np.newaxis`
-                self._masks[k] = LazyMask(mask=Ellipsis, mask_type=k)
             else:
-                self._masks[k] = LazyMask(mask=v, mask_type=k)
+                # a literal `None` mask would resolve like `np.newaxis`
+                # that would be confusing so replace with Ellipsis
+                self._masks[k] = LazyMask(mask=Ellipsis if v is None else v)
         return
 
     @classmethod
@@ -415,12 +407,7 @@ class MaskCollection(object):
         MaskCollection
             The collection of masks set to provided values, or the default ``Ellipsis``.
         """
-        return cls(
-            **{
-                k: LazyMask(mask=masks.get(k, Ellipsis), mask_type=k)
-                for k in mask_types
-            }
-        )
+        return cls(**{k: LazyMask(mask=masks.get(k, Ellipsis)) for k in mask_types})
 
     def __getattr__(self, attr: str) -> LazyMask:
         """
@@ -479,7 +466,10 @@ class MaskCollection(object):
         return MaskCollection(**{k: deepcopy(v) for k, v in self._masks.items()})
 
     def combine(
-        self, other_mask_collection: "MaskCollection", *, sg: "SWIFTGalaxy"
+        self,
+        other_mask_collection: "MaskCollection",
+        *,
+        sg: "SWIFTGalaxy",
     ) -> "MaskCollection":
         """
         Combine this :class:`~swiftgalaxy.masks.MaskCollection` with another.
@@ -503,7 +493,7 @@ class MaskCollection(object):
             this_mask = getattr(self, k)
             other_mask = getattr(other_mask_collection, k, None)
             return_collection[k] = (
-                this_mask._combined_with(other_mask, sg=sg)
+                this_mask._combined_with(other_mask, sg=sg, mask_type=k)
                 if other_mask is not None
                 else this_mask
             )

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -60,6 +60,7 @@ class LazyMask(object):
     _mask: MaskType
     _evaluated: bool
     _sg: "Optional[SWIFTGalaxy]"
+    _mask_type: "Optional[str]"
     _combinable: bool
 
     def __init__(
@@ -81,6 +82,7 @@ class LazyMask(object):
             self._mask_function = mask_function
             self._evaluated = True
         self._sg = sg
+        self._mask_type = None  # intended for MaskCollection to set
         self._combinable = combinable
         return
 
@@ -91,30 +93,23 @@ class LazyMask(object):
             self._mask = self._mask_function(self._sg)
             self._evaluated = True
 
-    def _make_combinable(self, sg: "SWIFTGalaxy", mask_type: str) -> None:
+    def _make_combinable(self) -> None:
         """
         Ensure that the mask can have an arbitrary second mask applied to combine them.
 
         This is done implicitly if the mask is not already evaluated, or explicitly
         otherwise.
-
-        Parameters
-        ----------
-        sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
-            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` that mask applies to.
-
-        mask_type : str
-            The particle type that this mask applies to.
         """
         # need to convert to an integer mask to combine
         # (boolean is insufficient in case of re-ordering masks)
-        if sg._spatial_mask is None:
+        assert self._sg is not None  # placate mypy
+        if self._sg._spatial_mask is None:
             # get a count of particles in the box
-            num_part = getattr(sg.metadata, f"n_{mask_type}")
+            num_part = getattr(self._sg.metadata, f"n_{self._mask_type}")
         else:  # sg._spatial_mask is not None
             # get a count of particles in the spatial mask region
             num_part = np.sum(
-                sg._spatial_mask.get_masked_counts_offsets()[0][mask_type]
+                self._sg._spatial_mask.get_masked_counts_offsets()[0][self._mask_type]
             )
         if self._mask_function is not None:
             old_mask_function = self._mask_function  # need reference to the current one
@@ -123,7 +118,7 @@ class LazyMask(object):
             self._mask = np.arange(num_part)[self._mask]
         self._combinable = True
 
-    def _combined_with(self, other_mask: "LazyMask", mask_type: str) -> "LazyMask":
+    def _combined_with(self, other_mask: "LazyMask") -> "LazyMask":
         """
         Combine two lazy masks into one, avoiding evaluating them.
 
@@ -135,9 +130,6 @@ class LazyMask(object):
         ----------
         other_mask : ~swiftgalaxy.masks.LazyMask
             The second mask to combine.
-
-        mask_type : str
-            The particle type that this mask applies to.
 
         Returns
         -------
@@ -175,7 +167,7 @@ class LazyMask(object):
                 The combined mask.
             """
             if not self._combinable:
-                self._make_combinable(sg=sg, mask_type=mask_type)
+                self._make_combinable()
             assert isinstance(self.mask, np.ndarray)  # placate mypy
             assert self.mask.dtype == int
             return self.mask[other_mask.mask]
@@ -391,9 +383,10 @@ class MaskCollection(object):
             if isinstance(v, LazyMask):
                 setattr(self, k, v)
             elif v is None:
-                pass
+                setattr(self, k, LazyMask(mask=Ellipsis))
             else:
                 setattr(self, k, LazyMask(mask=v))
+            getattr(self, k)._mask_type = k
         return
 
     def __getattr__(self, attr: str) -> None:
@@ -495,7 +488,7 @@ class MaskCollection(object):
                 # both are masks, combine
                 this_mask = getattr(self, k)
                 other_mask = getattr(other_mask_collection, k)
-                return_collection[k] = this_mask._combined_with(other_mask, mask_type=k)
+                return_collection[k] = this_mask._combined_with(other_mask)
             else:
                 # one xor other is mask, assign
                 if isinstance(getattr(self, k), LazyMask):

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -90,7 +90,7 @@ class LazyMask(object):
         """Force evaluation the mask function."""
         if not self._evaluated:
             assert self._mask_function is not None  # placate mypy
-            self._mask = self._mask_function(self._sg)
+            self._mask = self._mask_function()
             self._evaluated = True
 
     def _make_combinable(self) -> None:
@@ -113,7 +113,7 @@ class LazyMask(object):
             )
         if self._mask_function is not None:
             old_mask_function = self._mask_function  # need reference to the current one
-            self._mask_function = lambda sg: np.arange(num_part)[old_mask_function(sg)]
+            self._mask_function = lambda: np.arange(num_part)[old_mask_function()]
         if self._evaluated:
             self._mask = np.arange(num_part)[self._mask]
         self._combinable = True
@@ -151,15 +151,9 @@ class LazyMask(object):
             )
 
         # may as well always defer evaluating combination until it's asked for
-        def lazy_mask(_sg: "SWIFTGalaxy") -> NDArray:
+        def lazy_mask() -> NDArray:
             """
             Evaluate a mask combining two existing masks.
-
-            Parameters
-            ----------
-            _sg : ~swiftgalaxy.reader.SWIFTGalaxy
-                A reference to a :class:`~swiftgalaxy.reader.SWIFTGalaxy` that is made
-                available when evaluating the mask.
 
             Returns
             -------

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -53,7 +53,11 @@ class LazyMask(object):
     combinable : bool
         If ``True``, it declares that for this mask ``data[this_mask][other_mask]`` is
         equivalent to ``data[this_mask[other_mask]]``. This usually means that it is an
-        array of indices to select from ``data``.
+        array of integer indices to select from ``data``.
+
+    mask_type : str, default: ``None``
+        The :mod:`swiftsimio` "group_type" (e.g. ``"gas"``, ``"dark_matter"``, etc.) that
+        this mask applies to.
     """
 
     _mask_function: Optional[Callable]
@@ -69,6 +73,7 @@ class LazyMask(object):
         mask_function: Optional[Callable] = None,
         sg: "Optional[SWIFTGalaxy]" = None,
         combinable: bool = False,
+        mask_type: Optional[str] = None,
     ) -> None:
         if mask_function is None and mask is None:
             self._mask = None
@@ -82,7 +87,7 @@ class LazyMask(object):
             self._mask_function = mask_function
             self._evaluated = True
         self._sg = sg
-        self._mask_type = None  # intended for MaskCollection to set
+        self._mask_type = mask_type
         self._combinable = combinable
         return
 
@@ -136,18 +141,13 @@ class LazyMask(object):
         ~swiftgalaxy.masks.LazyMask
             The combined mask.
         """
-        if self._sg is not None and other_mask._sg is not None:
+        if self._sg is None:
+            raise ValueError(
+                "LazyMask must have associated SWIFTGalaxy to use _combined_with."
+            )
+        if other_mask._sg is not None:
             assert self._sg is other_mask._sg, (
                 "Masks must be for same SWIFTGalaxy to be combined."
-            )
-            sg = self._sg
-        elif self._sg is not None:
-            sg = self._sg
-        elif other_mask._sg is not None:
-            sg = other_mask._sg
-        else:
-            raise ValueError(
-                "At least one of LazyMask must have associated SWIFTGalaxy to combine."
             )
 
         # may as well always defer evaluating combination until it's asked for
@@ -166,7 +166,12 @@ class LazyMask(object):
             assert self.mask.dtype == int
             return self.mask[other_mask.mask]
 
-        return LazyMask(mask_function=lazy_mask, sg=sg, combinable=True)
+        return LazyMask(
+            mask_function=lazy_mask,
+            sg=self._sg,
+            combinable=True,
+            mask_type=self._mask_type,
+        )
 
     @property
     def mask(self) -> MaskType:
@@ -199,12 +204,14 @@ class LazyMask(object):
                 mask_function=self._mask_function,
                 sg=self._sg,
                 combinable=self._combinable,
+                mask_type=self._mask_type,
             )
         else:
             return LazyMask(
                 mask_function=self._mask_function,
                 sg=self._sg,
                 combinable=self._combinable,
+                mask_type=self._mask_type,
             )
 
     def __deepcopy__(self, memo: Optional[dict] = None) -> "LazyMask":
@@ -229,13 +236,15 @@ class LazyMask(object):
                 mask=deepcopy(self._mask),
                 mask_function=deepcopy(self._mask_function),
                 sg=self._sg,
-                combinable=self._combinable,
+                combinable=deepcopy(self._combinable),
+                mask_type=deepcopy(self._mask_type),
             )
         else:
             return LazyMask(
                 mask_function=deepcopy(self._mask_function),
                 sg=self._sg,
-                combinable=self._combinable,
+                combinable=deepcopy(self._combinable),
+                mask_type=deepcopy(self._mask_type),
             )
 
     def __eq__(self, other: object) -> bool:
@@ -316,16 +325,12 @@ class LazyMask(object):
         """
         Update the :class:`~swiftgalaxy.reader.SWIFTGalaxy` associated to the mask.
 
-        This :class:`~swiftgalaxy.masks.LazyMask` may have a reference to a
-        :class:`~swiftgalaxy.reader.SWIFTGalaxy`. If present, this function updates the
-        reference to a new one.
-
         Parameters
         ----------
         sg : ~swiftgalaxy.reader.SWIFTGalaxy
             The new :class:`~swiftgalaxy.reader.SWIFTGalaxy` reference to store.
         """
-        self._sg = sg if self._sg is not None else None
+        self._sg = sg
 
 
 class MaskCollection(object):
@@ -369,27 +374,32 @@ class MaskCollection(object):
         )
     """
 
+    _masks: dict[str, LazyMask]
+
     def __init__(
         self,
         **kwargs: Optional[Union[MaskType, LazyMask]],
     ) -> None:
+        self._masks = {}
         for k, v in kwargs.items():
             if isinstance(v, LazyMask):
-                setattr(self, k, v)
-            elif v is None:
-                setattr(self, k, LazyMask(mask=Ellipsis))
+                self._masks[k] = v
+                assert getattr(self, k)._mask_type == k, (
+                    f"Provide {k} `LazyMask`'s `mask_type` argument when initializing."
+                )
+            elif v is None:  # a literal `None` mask would resolve like `np.newaxis`
+                self._masks[k] = LazyMask(mask=Ellipsis, mask_type=k)
             else:
-                setattr(self, k, LazyMask(mask=v))
-            getattr(self, k)._mask_type = k
+                self._masks[k] = LazyMask(mask=v, mask_type=k)
         return
 
-    def __getattr__(self, attr: str) -> None:
+    def __getattr__(self, attr: str) -> LazyMask:
         """
-        Return ``None`` if an attribute of the object doesn't exist.
+        Access masks as attributes.
 
-        This function is called if an attribute is asked for and not found.
-        Instead of the usual behaviour of raising a :exc:`AttributeError`,
-        ``None`` is returned.
+        This function is called if an attribute is asked for and not found. In this case
+        the ``_masks`` dictionary is checked for a key matching the requested
+        attribute. It is returned if found, else a ``AttributeError`` is raised as usual.
 
         Parameters
         ----------
@@ -398,11 +408,15 @@ class MaskCollection(object):
 
         Returns
         -------
-        None
-            If we reach calling this function the attribute is not found and we
-            return ``None``.
+        ~swiftgalaxy.masks.LazyMask
+            The requested :class:`~swiftgalaxy.masks.LazyMask` from the ``_masks``.
         """
-        return None
+        try:
+            return self._masks[attr]
+        except KeyError:
+            raise AttributeError(
+                f"Attribute {attr} not found (and not a key of `_masks`)"
+            )
 
     def __copy__(self) -> "MaskCollection":
         """
@@ -415,7 +429,7 @@ class MaskCollection(object):
         :class:`~swiftgalaxy.masks.MaskCollection`
             The copy of the :class:`~swiftgalaxy.masks.MaskCollection`.
         """
-        return MaskCollection(**self.__dict__)
+        return MaskCollection(**self._masks)
 
     def __deepcopy__(self, memo: Optional[dict] = None) -> "MaskCollection":
         """
@@ -433,7 +447,7 @@ class MaskCollection(object):
         :class:`~swiftgalaxy.masks.MaskCollection`
             The copy of the :class:`~swiftgalaxy.masks.MaskCollection`.
         """
-        return MaskCollection(**{k: deepcopy(v) for k, v in self.__dict__.items()})
+        return MaskCollection(**{k: deepcopy(v) for k, v in self._masks.items()})
 
     def _update_sg(self, sg: "SWIFTGalaxy") -> None:
         """
@@ -448,9 +462,8 @@ class MaskCollection(object):
         sg : ~swiftgalaxy.reader.SWIFTGalaxy
             The new :class:`~swiftgalaxy.reader.SWIFTGalaxy` reference to store.
         """
-        for v in self.__dict__.values():
-            if isinstance(v, LazyMask):
-                v._update_sg(sg)
+        for v in self._masks.values():
+            v._update_sg(sg)
 
     def combine(self, other_mask_collection: "MaskCollection") -> "MaskCollection":
         """
@@ -466,27 +479,13 @@ class MaskCollection(object):
             The other mask collection to combine with this one.
         """
         return_collection = {}
-        all_keys = set(self.__dict__.keys()) | set(
-            other_mask_collection.__dict__.keys()
-        )
+        all_keys = set(self._masks.keys()) | set(other_mask_collection._masks.keys())
         for k in all_keys:
-            if not (
-                isinstance(getattr(self, k), LazyMask)
-                or isinstance(getattr(other_mask_collection, k), LazyMask)
-            ):
-                # this is not a mask field, skip
-                continue
-            elif isinstance(getattr(self, k), LazyMask) and isinstance(
-                getattr(other_mask_collection, k), LazyMask
-            ):
-                # both are masks, combine
-                this_mask = getattr(self, k)
-                other_mask = getattr(other_mask_collection, k)
-                return_collection[k] = this_mask._combined_with(other_mask)
-            else:
-                # one xor other is mask, assign
-                if isinstance(getattr(self, k), LazyMask):
-                    return_collection[k] = getattr(self, k)
-                else:  # isinstance(getattr(other_mask_collection, k), LazyMask)
-                    return_collection[k] = getattr(other_mask_collection, k)
+            this_mask = getattr(self, k)
+            other_mask = getattr(other_mask_collection, k, None)
+            return_collection[k] = (
+                this_mask._combined_with(other_mask)
+                if other_mask is not None
+                else this_mask
+            )
         return MaskCollection(**return_collection)

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -44,12 +44,6 @@ class LazyMask(object):
     mask_function : Callable, default: ``None``
         A reference to a function that returns a mask when called.
 
-    sg : ~swiftgalaxy.reader.SWIFTGalaxy, default: ``None``
-        A reference to a :class:`~swiftgalaxy.reader.SWIFTGalaxy` that is made available
-        when evaluating the mask. Stored separately from the mask evaluation function so
-        that it can be modified, for example when the :class:`~swiftgalaxy.masks.LazyMask`
-        is copied to a new object.
-
     combinable : bool
         If ``True``, it declares that for this mask ``data[this_mask][other_mask]`` is
         equivalent to ``data[this_mask[other_mask]]``. This usually means that it is an
@@ -63,7 +57,6 @@ class LazyMask(object):
     _mask_function: Optional[Callable]
     _mask: MaskType
     _evaluated: bool
-    _sg: "Optional[SWIFTGalaxy]"
     _mask_type: "Optional[str]"
     _combinable: bool
 
@@ -71,7 +64,6 @@ class LazyMask(object):
         self,
         mask: MaskType = None,
         mask_function: Optional[Callable] = None,
-        sg: "Optional[SWIFTGalaxy]" = None,
         combinable: bool = False,
         mask_type: Optional[str] = None,
     ) -> None:
@@ -86,7 +78,6 @@ class LazyMask(object):
             self._mask = mask
             self._mask_function = mask_function
             self._evaluated = True
-        self._sg = sg
         self._mask_type = mask_type
         self._combinable = combinable
         return
@@ -98,23 +89,28 @@ class LazyMask(object):
             self._mask = self._mask_function()
             self._evaluated = True
 
-    def _make_combinable(self) -> None:
+    def _make_combinable(self, sg: "SWIFTGalaxy") -> None:
         """
         Ensure that the mask can have an arbitrary second mask applied to combine them.
 
         This is done implicitly if the mask is not already evaluated, or explicitly
         otherwise.
+
+        Parameters
+        ----------
+        sg : ~swiftgalaxy.reader.SWIFTGalaxy
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to use to look up particle count
+            metadata.
         """
         # need to convert to an integer mask to combine
         # (boolean is insufficient in case of re-ordering masks)
-        assert self._sg is not None  # placate mypy
-        if self._sg._spatial_mask is None:
+        if sg._spatial_mask is None:
             # get a count of particles in the box
-            num_part = getattr(self._sg.metadata, f"n_{self._mask_type}")
+            num_part = getattr(sg.metadata, f"n_{self._mask_type}")
         else:  # sg._spatial_mask is not None
             # get a count of particles in the spatial mask region
             num_part = np.sum(
-                self._sg._spatial_mask.get_masked_counts_offsets()[0][self._mask_type]
+                sg._spatial_mask.get_masked_counts_offsets()[0][self._mask_type]
             )
         if self._mask_function is not None:
             old_mask_function = self._mask_function  # need reference to the current one
@@ -123,7 +119,9 @@ class LazyMask(object):
             self._mask = np.arange(num_part)[self._mask]
         self._combinable = True
 
-    def _combined_with(self, other_mask: "LazyMask") -> "LazyMask":
+    def _combined_with(
+        self, other_mask: "LazyMask", *, sg: "SWIFTGalaxy"
+    ) -> "LazyMask":
         """
         Combine two lazy masks into one, avoiding evaluating them.
 
@@ -136,15 +134,15 @@ class LazyMask(object):
         other_mask : ~swiftgalaxy.masks.LazyMask
             The second mask to combine.
 
+        sg : ~swiftgalaxy.reader.SWIFTGalaxy
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to use to look up particle count
+            metadata.
+
         Returns
         -------
         ~swiftgalaxy.masks.LazyMask
             The combined mask.
         """
-        if self._sg is None:
-            raise ValueError(
-                "LazyMask must have associated SWIFTGalaxy to use _combined_with."
-            )
 
         # may as well always defer evaluating combination until it's asked for
         def lazy_mask() -> NDArray:
@@ -157,14 +155,13 @@ class LazyMask(object):
                 The combined mask.
             """
             if not self._combinable:
-                self._make_combinable()
+                self._make_combinable(sg)
             assert isinstance(self.mask, np.ndarray)  # placate mypy
             assert self.mask.dtype == int
             return self.mask[other_mask.mask]
 
         return LazyMask(
             mask_function=lazy_mask,
-            sg=self._sg,
             combinable=True,
             mask_type=self._mask_type,
         )
@@ -198,14 +195,12 @@ class LazyMask(object):
             return LazyMask(
                 mask=self._mask,
                 mask_function=self._mask_function,
-                sg=self._sg,
                 combinable=self._combinable,
                 mask_type=self._mask_type,
             )
         else:
             return LazyMask(
                 mask_function=self._mask_function,
-                sg=self._sg,
                 combinable=self._combinable,
                 mask_type=self._mask_type,
             )
@@ -231,14 +226,12 @@ class LazyMask(object):
             return LazyMask(
                 mask=deepcopy(self._mask),
                 mask_function=deepcopy(self._mask_function),
-                sg=self._sg,
                 combinable=deepcopy(self._combinable),
                 mask_type=deepcopy(self._mask_type),
             )
         else:
             return LazyMask(
                 mask_function=deepcopy(self._mask_function),
-                sg=self._sg,
                 combinable=deepcopy(self._combinable),
                 mask_type=deepcopy(self._mask_type),
             )
@@ -380,9 +373,7 @@ class MaskCollection(object):
         return
 
     @classmethod
-    def _blank_from_mask_types(
-        cls, mask_types: tuple[str], sg: "Optional[SWIFTGalaxy]" = None
-    ) -> "MaskCollection":
+    def _blank_from_mask_types(cls, mask_types: tuple[str]) -> "MaskCollection":
         """
         Make a set of masks for a list of types where all the masks are just ``Ellipsis``.
 
@@ -391,21 +382,17 @@ class MaskCollection(object):
         mask_types : tuple
             The list of mask types (strings, e.g. ``"gas"``, ``"dark_matter"``, etc.).
 
-        sg : ~swiftgalaxy.reader.SWIFTGalaxy
-            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to associate with the masks.
-
         Returns
         -------
         MaskCollection
             The collection of masks with all masks set to ``Ellipsis``.
         """
-        return cls._from_mask_types_and_values(mask_types=mask_types, sg=sg)
+        return cls._from_mask_types_and_values(mask_types=mask_types)
 
     @classmethod
     def _from_mask_types_and_values(
         cls,
         mask_types: tuple[str],
-        sg: "Optional[SWIFTGalaxy]" = None,
         masks: dict[str, MaskType] = {},
     ) -> "MaskCollection":
         """
@@ -415,9 +402,6 @@ class MaskCollection(object):
         ----------
         mask_types : tuple
             The list of mask types (strings, e.g. ``"gas"``, ``"dark_matter"``, etc.).
-
-        sg : ~swiftgalaxy.reader.SWIFTGalaxy
-            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to associate with the masks.
 
         masks : dict
             A dictionary with keys corresponding to (some of) ``mask_types`` and values
@@ -433,7 +417,7 @@ class MaskCollection(object):
         """
         return cls(
             **{
-                k: LazyMask(mask=masks.get(k, Ellipsis), sg=sg, mask_type=k)
+                k: LazyMask(mask=masks.get(k, Ellipsis), mask_type=k)
                 for k in mask_types
             }
         )
@@ -494,7 +478,9 @@ class MaskCollection(object):
         """
         return MaskCollection(**{k: deepcopy(v) for k, v in self._masks.items()})
 
-    def combine(self, other_mask_collection: "MaskCollection") -> "MaskCollection":
+    def combine(
+        self, other_mask_collection: "MaskCollection", *, sg: "SWIFTGalaxy"
+    ) -> "MaskCollection":
         """
         Combine this :class:`~swiftgalaxy.masks.MaskCollection` with another.
 
@@ -506,6 +492,10 @@ class MaskCollection(object):
         ----------
         other_mask_collection : ~swiftgalaxy.masks.MaskCollection
             The other mask collection to combine with this one.
+
+        sg : ~swiftgalaxy.reader.SWIFTGalaxy
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to use to look up particle count
+            metadata.
         """
         return_collection = {}
         all_keys = set(self._masks.keys()) | set(other_mask_collection._masks.keys())
@@ -513,7 +503,7 @@ class MaskCollection(object):
             this_mask = getattr(self, k)
             other_mask = getattr(other_mask_collection, k, None)
             return_collection[k] = (
-                this_mask._combined_with(other_mask)
+                this_mask._combined_with(other_mask, sg=sg)
                 if other_mask is not None
                 else this_mask
             )

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -145,10 +145,6 @@ class LazyMask(object):
             raise ValueError(
                 "LazyMask must have associated SWIFTGalaxy to use _combined_with."
             )
-        if other_mask._sg is not None:
-            assert self._sg is other_mask._sg, (
-                "Masks must be for same SWIFTGalaxy to be combined."
-            )
 
         # may as well always defer evaluating combination until it's asked for
         def lazy_mask() -> NDArray:
@@ -321,17 +317,6 @@ class LazyMask(object):
         """
         return not self.__eq__(other)
 
-    def _update_sg(self, sg: "SWIFTGalaxy") -> None:
-        """
-        Update the :class:`~swiftgalaxy.reader.SWIFTGalaxy` associated to the mask.
-
-        Parameters
-        ----------
-        sg : ~swiftgalaxy.reader.SWIFTGalaxy
-            The new :class:`~swiftgalaxy.reader.SWIFTGalaxy` reference to store.
-        """
-        self._sg = sg
-
 
 class MaskCollection(object):
     """
@@ -385,13 +370,73 @@ class MaskCollection(object):
             if isinstance(v, LazyMask):
                 self._masks[k] = v
                 assert getattr(self, k)._mask_type == k, (
-                    f"Provide {k} `LazyMask`'s `mask_type` argument when initializing."
+                    f"`LazyMask` for {k} has non-matching "
+                    f"`mask_type` {getattr(self, k)._mark_type}."
                 )
             elif v is None:  # a literal `None` mask would resolve like `np.newaxis`
                 self._masks[k] = LazyMask(mask=Ellipsis, mask_type=k)
             else:
                 self._masks[k] = LazyMask(mask=v, mask_type=k)
         return
+
+    @classmethod
+    def _blank_from_mask_types(
+        cls, mask_types: tuple[str], sg: "Optional[SWIFTGalaxy]" = None
+    ) -> "MaskCollection":
+        """
+        Make a set of masks for a list of types where all the masks are just ``Ellipsis``.
+
+        Parameters
+        ----------
+        mask_types : tuple
+            The list of mask types (strings, e.g. ``"gas"``, ``"dark_matter"``, etc.).
+
+        sg : ~swiftgalaxy.reader.SWIFTGalaxy
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to associate with the masks.
+
+        Returns
+        -------
+        MaskCollection
+            The collection of masks with all masks set to ``Ellipsis``.
+        """
+        return cls._from_mask_types_and_values(mask_types=mask_types, sg=sg)
+
+    @classmethod
+    def _from_mask_types_and_values(
+        cls,
+        mask_types: tuple[str],
+        sg: "Optional[SWIFTGalaxy]" = None,
+        masks: dict[str, MaskType] = {},
+    ) -> "MaskCollection":
+        """
+        Make a set of masks for a list of mask types, defaulting to ``Ellipsis``.
+
+        Parameters
+        ----------
+        mask_types : tuple
+            The list of mask types (strings, e.g. ``"gas"``, ``"dark_matter"``, etc.).
+
+        sg : ~swiftgalaxy.reader.SWIFTGalaxy
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to associate with the masks.
+
+        masks : dict
+            A dictionary with keys corresponding to (some of) ``mask_types`` and values
+            containing the masks (boolean array, slice, index array, etc. - not
+            :class:`~swiftgalaxy.masks.LazyMask`) to use for those keys. Any elements of
+            ``mask_types`` without a corresponding entry in this dictionary get a default
+            mask value of ``Ellipsis``.
+
+        Returns
+        -------
+        MaskCollection
+            The collection of masks set to provided values, or the default ``Ellipsis``.
+        """
+        return cls(
+            **{
+                k: LazyMask(mask=masks.get(k, Ellipsis), sg=sg, mask_type=k)
+                for k in mask_types
+            }
+        )
 
     def __getattr__(self, attr: str) -> LazyMask:
         """
@@ -448,22 +493,6 @@ class MaskCollection(object):
             The copy of the :class:`~swiftgalaxy.masks.MaskCollection`.
         """
         return MaskCollection(**{k: deepcopy(v) for k, v in self._masks.items()})
-
-    def _update_sg(self, sg: "SWIFTGalaxy") -> None:
-        """
-        Update the :class:`~swiftgalaxy.reader.SWIFTGalaxy` associated to masks.
-
-        :class:`~swiftgalaxy.masks.LazyMask` instances contained in this collection may
-        have a reference to a :class:`~swiftgalaxy.reader.SWIFTGalaxy`. This function
-        updates the reference to a new one.
-
-        Parameters
-        ----------
-        sg : ~swiftgalaxy.reader.SWIFTGalaxy
-            The new :class:`~swiftgalaxy.reader.SWIFTGalaxy` reference to store.
-        """
-        for v in self._masks.values():
-            v._update_sg(sg)
 
     def combine(self, other_mask_collection: "MaskCollection") -> "MaskCollection":
         """

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -91,9 +91,7 @@ class LazyMask(object):
             self._mask = self._mask_function(self._sg)
             self._evaluated = True
 
-    def _make_combinable(
-        self, sg: "Optional[SWIFTGalaxy]", active_sg: "SWIFTGalaxy", mask_type: str
-    ) -> None:
+    def _make_combinable(self, sg: "SWIFTGalaxy", mask_type: str) -> None:
         """
         Ensure that the mask can have an arbitrary second mask applied to combine them.
 
@@ -103,21 +101,14 @@ class LazyMask(object):
         Parameters
         ----------
         sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
-            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` that mask applies to, if
-            available.
-
-        active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
-            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked right now,
-            used to determine particle counts if `sg` is unavailable.
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` that mask applies to.
 
         mask_type : str
             The particle type that this mask applies to.
         """
         # need to convert to an integer mask to combine
         # (boolean is insufficient in case of re-ordering masks)
-        if sg is None:
-            num_part = getattr(active_sg.metadata, f"n_{mask_type}")
-        elif sg._spatial_mask is None:
+        if sg._spatial_mask is None:
             # get a count of particles in the box
             num_part = getattr(sg.metadata, f"n_{mask_type}")
         else:  # sg._spatial_mask is not None
@@ -131,6 +122,65 @@ class LazyMask(object):
         if self._evaluated:
             self._mask = np.arange(num_part)[self._mask]
         self._combinable = True
+
+    def _combined_with(self, other_mask: "LazyMask", mask_type: str) -> "LazyMask":
+        """
+        Combine two lazy masks into one, avoiding evaluating them.
+
+        The first mask may be "combinable", which means that the second mask can be
+        applied directly to the first. If this flag is not set we first need to make it
+        combinable.
+
+        Parameters
+        ----------
+        other_mask : ~swiftgalaxy.masks.LazyMask
+            The second mask to combine.
+
+        mask_type : str
+            The particle type that this mask applies to.
+
+        Returns
+        -------
+        ~swiftgalaxy.masks.LazyMask
+            The combined mask.
+        """
+        if self._sg is not None and other_mask._sg is not None:
+            assert self._sg is other_mask._sg, (
+                "Masks must be for same SWIFTGalaxy to be combined."
+            )
+            sg = self._sg
+        elif self._sg is not None:
+            sg = self._sg
+        elif other_mask._sg is not None:
+            sg = other_mask._sg
+        else:
+            raise ValueError(
+                "At least one of LazyMask must have associated SWIFTGalaxy to combine."
+            )
+
+        # may as well always defer evaluating combination until it's asked for
+        def lazy_mask(_sg: "SWIFTGalaxy") -> NDArray:
+            """
+            Evaluate a mask combining two existing masks.
+
+            Parameters
+            ----------
+            _sg : ~swiftgalaxy.reader.SWIFTGalaxy
+                A reference to a :class:`~swiftgalaxy.reader.SWIFTGalaxy` that is made
+                available when evaluating the mask.
+
+            Returns
+            -------
+            :class:`~numpy.ndarray`
+                The combined mask.
+            """
+            if not self._combinable:
+                self._make_combinable(sg=sg, mask_type=mask_type)
+            assert isinstance(self.mask, np.ndarray)  # placate mypy
+            assert self.mask.dtype == int
+            return self.mask[other_mask.mask]
+
+        return LazyMask(mask_function=lazy_mask, sg=sg, combinable=True)
 
     @property
     def mask(self) -> MaskType:
@@ -445,9 +495,7 @@ class MaskCollection(object):
                 # both are masks, combine
                 this_mask = getattr(self, k)
                 other_mask = getattr(other_mask_collection, k)
-                return_collection[k] = _combine_lazy_masks(
-                    this_mask, other_mask, mask_type=k
-                )
+                return_collection[k] = this_mask._combined_with(other_mask, mask_type=k)
             else:
                 # one xor other is mask, assign
                 if isinstance(getattr(self, k), LazyMask):
@@ -455,64 +503,3 @@ class MaskCollection(object):
                 else:  # isinstance(getattr(other_mask_collection, k), LazyMask)
                     return_collection[k] = getattr(other_mask_collection, k)
         return MaskCollection(**return_collection)
-
-
-def _combine_lazy_masks(
-    first_mask: LazyMask, second_mask: LazyMask, mask_type: str
-) -> LazyMask:
-    """
-    Combine two lazy masks into one, avoiding evaluating them.
-
-    The first mask may be "combinable", which means that the second mask can be applied
-    directly to the first. If this flag is not set we first need to make it combinable.
-
-    Parameters
-    ----------
-    first_mask : ~swiftgalaxy.masks.LazyMask
-        The first mask to combine.
-
-    second_mask : ~swiftgalaxy.masks.LazyMask
-        The second mask to combine.
-
-    mask_type : str
-        The particle type that this mask applies to.
-
-    Returns
-    -------
-    ~swiftgalaxy.masks.LazyMask
-        The combined mask.
-    """
-    if first_mask._sg is not None and second_mask._sg is not None:
-        assert first_mask._sg is second_mask._sg, (
-            "Masks must be for same SWIFTGalaxy to be combined."
-        )
-        sg = first_mask._sg
-    elif first_mask._sg is not None:
-        sg = first_mask._sg
-    elif second_mask._sg is not None:
-        sg = second_mask._sg
-    else:
-        sg = None
-
-    # may as well always defer evaluating combination until it's asked for
-    def lazy_mask(active_sg: "SWIFTGalaxy") -> NDArray:
-        """
-        Evaluate a mask combining two existing masks.
-
-        Parameters
-        ----------
-        active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
-            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked.
-
-        Returns
-        -------
-        :class:`~numpy.ndarray`
-            The combined mask.
-        """
-        if not first_mask._combinable:
-            first_mask._make_combinable(sg=sg, active_sg=active_sg, mask_type=mask_type)
-        assert isinstance(first_mask.mask, np.ndarray)  # placate mypy
-        assert first_mask.mask.dtype == int
-        return first_mask.mask[second_mask.mask]
-
-    return LazyMask(mask_function=lazy_mask, sg=sg, combinable=True)

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -13,6 +13,7 @@ selection of particles of different types for use with
 """
 
 from copy import deepcopy
+from warnings import warn
 from typing import Optional, Union, Callable, TYPE_CHECKING
 from types import EllipsisType
 import numpy as np
@@ -465,7 +466,7 @@ class MaskCollection(object):
         """
         return MaskCollection(**{k: deepcopy(v) for k, v in self._masks.items()})
 
-    def combine(
+    def combined_with(
         self,
         other_mask_collection: "MaskCollection",
         *,
@@ -476,7 +477,7 @@ class MaskCollection(object):
 
         ``data[this_mask.<type>.mask][other_mask.<type>.mask]`` and
         ``data[combined_mask.<type>.mask]`` are equivalent, where
-        ``combined_mask = this_mask.combine(other_mask)``.
+        ``combined_mask = this_mask.combined_with(other_mask)``.
 
         Parameters
         ----------
@@ -488,8 +489,14 @@ class MaskCollection(object):
             metadata.
         """
         return_collection = {}
-        all_keys = set(self._masks.keys()) | set(other_mask_collection._masks.keys())
-        for k in all_keys:
+        if not set(other_mask_collection._masks.keys()).issubset(
+            set(self._masks.keys())
+        ):
+            extra_fields = set(
+                other_mask_collection._masks.keys() - set(self._masks.keys())
+            )
+            warn(f"Unexpected fields {extra_fields} in `other_mask_collection`.")
+        for k in self._masks.keys():
             this_mask = getattr(self, k)
             other_mask = getattr(other_mask_collection, k, None)
             return_collection[k] = (

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -40,16 +40,24 @@ class LazyMask(object):
 
     mask_function : Callable, default: ``None``
         A reference to a function that returns a mask when called.
+
+    sg : ~swiftgalaxy.reader.SWIFTGalaxy, default: ``None``
+        A reference to a :class:`~swiftgalaxy.reader.SWIFTGalaxy` that is made available
+        when evaluating the mask. Stored separately from the mask evaluation function so
+        that it can be modified, for example when the :class:`~swiftgalaxy.masks.LazyMask`
+        is copied to a new object.
     """
 
     _mask_function: Optional[Callable]
     _mask: Optional[Union[slice, EllipsisType, ArrayLike]]
     _evaluated: bool
+    _sg: "Optional[SWIFTGalaxy]"
 
     def __init__(
         self,
         mask: Optional[Union[slice, EllipsisType, ArrayLike]] = None,
         mask_function: Optional[Callable] = None,
+        sg: "Optional[SWIFTGalaxy]" = None,
     ) -> None:
         if mask_function is None and mask is None:
             self._mask = None
@@ -62,34 +70,20 @@ class LazyMask(object):
             self._mask = mask
             self._mask_function = mask_function
             self._evaluated = True
+        self._sg = sg
         return
 
-    def _evaluate(self, sg: "SWIFTGalaxy") -> None:
-        """
-        Force evaluation the mask function.
-
-        Parameters
-        ----------
-        sg : ~swiftgalaxy.reader.SWIFTGalaxy
-            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to pass to the ``mask_function``
-            during evaluation.
-        """
+    def _evaluate(self) -> None:
+        """Force evaluation the mask function."""
         if not self._evaluated:
             assert self._mask_function is not None  # placate mypy
-            self._mask = self._mask_function(sg)
+            self._mask = self._mask_function(self._sg)
             self._evaluated = True
 
-    def mask(
-        self, sg: "SWIFTGalaxy"
-    ) -> Optional[Union[slice, EllipsisType, ArrayLike]]:
+    @property
+    def mask(self) -> Optional[Union[slice, EllipsisType, ArrayLike]]:
         """
         Get the explicitly evaluated mask, evaluating it if necessary.
-
-        Parameters
-        ----------
-        sg : ~swiftgalaxy.reader.SWIFTGalaxy
-            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to pass to the ``mask_function``
-            during evaluation.
 
         Returns
         -------
@@ -97,7 +91,7 @@ class LazyMask(object):
             The explicitly evaluated mask.
         """
         if not self._evaluated:
-            self._evaluate(sg)
+            self._evaluate()
         return self._mask
 
     def __copy__(self) -> "LazyMask":
@@ -112,15 +106,18 @@ class LazyMask(object):
             The copy of the :class:`~swiftgalaxy.masks.LazyMask`.
         """
         if self._evaluated:
-            return LazyMask(mask=self._mask, mask_function=self._mask_function)
+            return LazyMask(
+                mask=self._mask, mask_function=self._mask_function, sg=self._sg
+            )
         else:
-            return LazyMask(mask_function=self._mask_function)
+            return LazyMask(mask_function=self._mask_function, sg=self._sg)
 
     def __deepcopy__(self, memo: Optional[dict] = None) -> "LazyMask":
         """
         Make a copy of the :class:`~swiftgalaxy.masks.LazyMask`.
 
-        This copies data (a "deep" copy).
+        This copies data (a "deep" copy). Does not deep-copy the reference to the
+        swiftgalaxy object, which should be replaced after copying if required.
 
         Parameters
         ----------
@@ -134,10 +131,12 @@ class LazyMask(object):
         """
         if self._evaluated:
             return LazyMask(
-                mask=deepcopy(self._mask), mask_function=deepcopy(self._mask_function)
+                mask=deepcopy(self._mask),
+                mask_function=deepcopy(self._mask_function),
+                sg=self._sg,
             )
         else:
-            return LazyMask(mask_function=deepcopy(self._mask_function))
+            return LazyMask(mask_function=deepcopy(self._mask_function), sg=self._sg)
 
     def __eq__(self, other: object) -> bool:
         """
@@ -212,6 +211,21 @@ class LazyMask(object):
             evaluated.
         """
         return not self.__eq__(other)
+
+    def _update_sg(self, sg: "SWIFTGalaxy") -> None:
+        """
+        Update the :class:`~swiftgalaxy.reader.SWIFTGalaxy` associated to the mask.
+
+        This :class:`~swiftgalaxy.masks.LazyMask` may have a reference to a
+        :class:`~swiftgalaxy.reader.SWIFTGalaxy`. If present, this function updates the
+        reference to a new one.
+
+        Parameters
+        ----------
+        sg : ~swiftgalaxy.reader.SWIFTGalaxy
+            The new :class:`~swiftgalaxy.reader.SWIFTGalaxy` reference to store.
+        """
+        self._sg = sg if self._sg is not None else None
 
 
 class MaskCollection(object):
@@ -319,3 +333,20 @@ class MaskCollection(object):
             The copy of the :class:`~swiftgalaxy.masks.MaskCollection`.
         """
         return MaskCollection(**{k: deepcopy(v) for k, v in self.__dict__.items()})
+
+    def _update_sg(self, sg: "SWIFTGalaxy") -> None:
+        """
+        Update the :class:`~swiftgalaxy.reader.SWIFTGalaxy` associated to masks.
+
+        :class:`~swiftgalaxy.masks.LazyMask` instances contained in this collection may
+        have a reference to a :class:`~swiftgalaxy.reader.SWIFTGalaxy`. This function
+        updates the reference to a new one.
+
+        Parameters
+        ----------
+        sg : ~swiftgalaxy.reader.SWIFTGalaxy
+            The new :class:`~swiftgalaxy.reader.SWIFTGalaxy` reference to store.
+        """
+        for v in self.__dict__.values():
+            if isinstance(v, LazyMask):
+                v._update_sg(sg)

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -49,18 +49,25 @@ class LazyMask(object):
         when evaluating the mask. Stored separately from the mask evaluation function so
         that it can be modified, for example when the :class:`~swiftgalaxy.masks.LazyMask`
         is copied to a new object.
+
+    combinable : bool
+        If ``True``, it declares that for this mask ``data[this_mask][other_mask]`` is
+        equivalent to ``data[this_mask[other_mask]]``. This usually means that it is an
+        array of indices to select from ``data``.
     """
 
     _mask_function: Optional[Callable]
     _mask: MaskType
     _evaluated: bool
     _sg: "Optional[SWIFTGalaxy]"
+    _combinable: bool
 
     def __init__(
         self,
         mask: MaskType = None,
         mask_function: Optional[Callable] = None,
         sg: "Optional[SWIFTGalaxy]" = None,
+        combinable: bool = False,
     ) -> None:
         if mask_function is None and mask is None:
             self._mask = None
@@ -74,6 +81,7 @@ class LazyMask(object):
             self._mask_function = mask_function
             self._evaluated = True
         self._sg = sg
+        self._combinable = combinable
         return
 
     def _evaluate(self) -> None:
@@ -82,6 +90,47 @@ class LazyMask(object):
             assert self._mask_function is not None  # placate mypy
             self._mask = self._mask_function(self._sg)
             self._evaluated = True
+
+    def _make_combinable(
+        self, sg: "Optional[SWIFTGalaxy]", active_sg: "SWIFTGalaxy", mask_type: str
+    ) -> None:
+        """
+        Ensure that the mask can have an arbitrary second mask applied to combine them.
+
+        This is done implicitly if the mask is not already evaluated, or explicitly
+        otherwise.
+
+        Parameters
+        ----------
+        sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` that mask applies to, if
+            available.
+
+        active_sg : :class:`~swiftgalaxy.reader.SWIFTGalaxy`
+            The :class:`~swiftgalaxy.reader.SWIFTGalaxy` instance being masked right now,
+            used to determine particle counts if `sg` is unavailable.
+
+        mask_type : str
+            The particle type that this mask applies to.
+        """
+        # need to convert to an integer mask to combine
+        # (boolean is insufficient in case of re-ordering masks)
+        if sg is None:
+            num_part = getattr(active_sg.metadata, f"n_{mask_type}")
+        elif sg._spatial_mask is None:
+            # get a count of particles in the box
+            num_part = getattr(sg.metadata, f"n_{mask_type}")
+        else:  # sg._spatial_mask is not None
+            # get a count of particles in the spatial mask region
+            num_part = np.sum(
+                sg._spatial_mask.get_masked_counts_offsets()[0][mask_type]
+            )
+        if self._mask_function is not None:
+            old_mask_function = self._mask_function  # need reference to the current one
+            self._mask_function = lambda sg: np.arange(num_part)[old_mask_function(sg)]
+        if self._evaluated:
+            self._mask = np.arange(num_part)[self._mask]
+        self._combinable = True
 
     @property
     def mask(self) -> MaskType:
@@ -110,10 +159,17 @@ class LazyMask(object):
         """
         if self._evaluated:
             return LazyMask(
-                mask=self._mask, mask_function=self._mask_function, sg=self._sg
+                mask=self._mask,
+                mask_function=self._mask_function,
+                sg=self._sg,
+                combinable=self._combinable,
             )
         else:
-            return LazyMask(mask_function=self._mask_function, sg=self._sg)
+            return LazyMask(
+                mask_function=self._mask_function,
+                sg=self._sg,
+                combinable=self._combinable,
+            )
 
     def __deepcopy__(self, memo: Optional[dict] = None) -> "LazyMask":
         """
@@ -137,9 +193,14 @@ class LazyMask(object):
                 mask=deepcopy(self._mask),
                 mask_function=deepcopy(self._mask_function),
                 sg=self._sg,
+                combinable=self._combinable,
             )
         else:
-            return LazyMask(mask_function=deepcopy(self._mask_function), sg=self._sg)
+            return LazyMask(
+                mask_function=deepcopy(self._mask_function),
+                sg=self._sg,
+                combinable=self._combinable,
+            )
 
     def __eq__(self, other: object) -> bool:
         """
@@ -402,6 +463,9 @@ def _combine_lazy_masks(
     """
     Combine two lazy masks into one, avoiding evaluating them.
 
+    The first mask may be "combinable", which means that the second mask can be applied
+    directly to the first. If this flag is not set we first need to make it combinable.
+
     Parameters
     ----------
     first_mask : ~swiftgalaxy.masks.LazyMask
@@ -445,18 +509,10 @@ def _combine_lazy_masks(
         :class:`~numpy.ndarray`
             The combined mask.
         """
-        # need to convert to an integer mask to combine
-        # (boolean is insufficient in case of re-ordering masks)
-        if sg is None:
-            num_part = getattr(active_sg.metadata, f"n_{mask_type}")
-        elif sg._spatial_mask is None:
-            # get a count of particles in the box
-            num_part = getattr(sg.metadata, f"n_{mask_type}")
-        else:  # sg._spatial_mask is not None
-            # get a count of particles in the spatial mask region
-            num_part = np.sum(
-                sg._spatial_mask.get_masked_counts_offsets()[0][mask_type]
-            )
-        return np.arange(num_part)[first_mask.mask][second_mask.mask]
+        if not first_mask._combinable:
+            first_mask._make_combinable(sg=sg, active_sg=active_sg, mask_type=mask_type)
+        assert isinstance(first_mask.mask, np.ndarray)  # placate mypy
+        assert first_mask.mask.dtype == int
+        return first_mask.mask[second_mask.mask]
 
-    return LazyMask(mask_function=lazy_mask, sg=sg)
+    return LazyMask(mask_function=lazy_mask, sg=sg, combinable=True)

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -803,7 +803,7 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
             :class:`~swiftgalaxy.reader._SWIFTGroupDatasetHelper` object.
         """
         mask_collection = MaskCollection._from_mask_types_and_values(
-            self.metadata.present_group_names, sg=self, masks={self.group_name: mask}
+            self.metadata.present_group_names, masks={self.group_name: mask}
         )
         return getattr(
             self._swiftgalaxy._data_copy(mask_collection=mask_collection),
@@ -1667,7 +1667,7 @@ class SWIFTGalaxy(SWIFTDataset):
         else:
             # in server mode we don't have a halo_catalogue yet
             self._extra_mask = MaskCollection._blank_from_mask_types(
-                self.metadata.present_group_names, sg=self
+                self.metadata.present_group_names
             )
 
         if auto_recentre and self.halo_catalogue is not None:
@@ -1787,7 +1787,7 @@ class SWIFTGalaxy(SWIFTDataset):
             sg._extra_mask = _extra_mask
         else:
             sg._extra_mask = MaskCollection._blank_from_mask_types(
-                sg.metadata.present_group_names, sg=sg
+                sg.metadata.present_group_names
             )
         if _coordinate_like_transform is not None:
             sg._coordinate_like_transform = _coordinate_like_transform
@@ -1927,7 +1927,7 @@ class SWIFTGalaxy(SWIFTDataset):
             mask = getattr(
                 mask_collection,
                 particle_name,
-                LazyMask(mask=Ellipsis, sg=sg, mask_type=particle_name),
+                LazyMask(mask=Ellipsis, mask_type=particle_name),
             )
             getattr(sg, particle_name)._mask_dataset(mask)
             for field_name in particle_metadata.field_names:
@@ -1982,7 +1982,7 @@ class SWIFTGalaxy(SWIFTDataset):
                         particle_dataset_helper._cylindrical_velocities[c][mask.mask]
                     )
         if mask_collection is not None:
-            sg._extra_mask = sg._extra_mask.combine(mask_collection)
+            sg._extra_mask = sg._extra_mask.combine(mask_collection, sg=sg)
         return sg
 
     def rotate(self, rotation: Rotation) -> None:
@@ -2334,7 +2334,7 @@ class SWIFTGalaxy(SWIFTDataset):
             if mask is not None:
                 getattr(self, particle_name)._mask_dataset(mask)
         assert self._extra_mask is not None
-        self._extra_mask = self._extra_mask.combine(mask_collection)
+        self._extra_mask = self._extra_mask.combine(mask_collection, sg=self)
         return
 
     def _append_to_coordinate_like_transform(

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -1526,7 +1526,7 @@ class SWIFTGalaxy(SWIFTDataset):
     coordinates_dataset_name: str
     velocities_dataset_name: str
     _spatial_mask: SWIFTMask
-    _extra_mask: Optional[MaskCollection]
+    _extra_mask: MaskCollection
     _data_server: "SWIFTGalaxy"
 
     def __init__(
@@ -1672,7 +1672,10 @@ class SWIFTGalaxy(SWIFTDataset):
             self._extra_mask = self.halo_catalogue._get_extra_mask(self)
         else:
             self._extra_mask = MaskCollection(
-                **{k: None for k in self.metadata.present_group_names}
+                **{
+                    k: LazyMask(mask=Ellipsis, sg=self)
+                    for k in self.metadata.present_group_names
+                }
             )
 
         if auto_recentre and self.halo_catalogue is not None:
@@ -1984,8 +1987,8 @@ class SWIFTGalaxy(SWIFTDataset):
                     new_particle_dataset_helper._cylindrical_velocities[c] = (
                         particle_dataset_helper._cylindrical_velocities[c][mask.mask]
                     )
-        assert sg._extra_mask is not None
         if mask_collection is not None:
+            mask_collection._update_sg(sg)
             sg._extra_mask = sg._extra_mask.combine(mask_collection)
         sg._extra_mask._update_sg(sg)
         return sg

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -852,7 +852,7 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
         """
         mask = getattr(self._swiftgalaxy._extra_mask, self._particle_dataset.group_name)
         if mask is not None:
-            return data[mask.mask(self._swiftgalaxy)]
+            return data[mask.mask]
         return data
 
     def _mask_dataset(self, mask: LazyMask) -> None:
@@ -877,7 +877,7 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
         # are in memory and have the old mask applied, if any:
         old_mask = getattr(self._swiftgalaxy._extra_mask, particle_name)
         if old_mask is not None:
-            old_mask._evaluate(self._swiftgalaxy)
+            old_mask._evaluate()
         # apply the new mask to any data already in memory:
         for field_name in particle_metadata.field_names:
             if self._is_namedcolumns(field_name):
@@ -892,15 +892,13 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
                         setattr(
                             getattr(self, field_name),
                             named_column,
-                            getattr(getattr(self, field_name), named_column)[
-                                mask.mask(self._swiftgalaxy)
-                            ],
+                            getattr(getattr(self, field_name), named_column)[mask.mask],
                         )
             elif getattr(self._particle_dataset, f"_{field_name}") is not None:
                 setattr(
                     self,
                     field_name,
-                    getattr(self, field_name)[mask.mask(self._swiftgalaxy)],
+                    getattr(self, field_name)[mask.mask],
                 )
         # also the derived coordinates, if any:
         self._mask_derived_coordinates(mask)
@@ -922,11 +920,7 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
             setattr(
                 self._swiftgalaxy._extra_mask,
                 particle_name,
-                LazyMask(
-                    mask=np.arange(num_part, dtype=int)[
-                        old_mask.mask(self._swiftgalaxy)
-                    ][mask.mask(self._swiftgalaxy)]
-                ),
+                LazyMask(mask=np.arange(num_part, dtype=int)[old_mask.mask][mask.mask]),
             )
         return
 
@@ -1378,25 +1372,21 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
             for coord in ("r", "theta", "phi"):
                 self._spherical_coordinates[f"_{coord}"] = self._spherical_coordinates[
                     f"_{coord}"
-                ][mask.mask(self._swiftgalaxy)]
+                ][mask.mask]
         if self._spherical_velocities is not None:
             for coord in ("v_r", "v_t", "v_p"):
                 self._spherical_velocities[f"_{coord}"] = self._spherical_velocities[
                     f"_{coord}"
-                ][mask.mask(self._swiftgalaxy)]
+                ][mask.mask]
         if self._cylindrical_coordinates is not None:
             for coord in ("rho", "phi", "z"):
                 self._cylindrical_coordinates[f"_{coord}"] = (
-                    self._cylindrical_coordinates[f"_{coord}"][
-                        mask.mask(self._swiftgalaxy)
-                    ]
+                    self._cylindrical_coordinates[f"_{coord}"][mask.mask]
                 )
         if self._cylindrical_velocities is not None:
             for coord in ("v_rho", "v_phi", "v_z"):
                 self._cylindrical_velocities[f"_{coord}"] = (
-                    self._cylindrical_velocities[f"_{coord}"][
-                        mask.mask(self._swiftgalaxy)
-                    ]
+                    self._cylindrical_velocities[f"_{coord}"][mask.mask]
                 )
         return
 
@@ -1825,6 +1815,7 @@ class SWIFTGalaxy(SWIFTDataset):
         )
         if _extra_mask is not None:
             sg._extra_mask = _extra_mask
+            sg._extra_mask._update_sg(sg)
         if _coordinate_like_transform is not None:
             sg._coordinate_like_transform = _coordinate_like_transform
         if _velocity_like_transform is not None:
@@ -1982,7 +1973,7 @@ class SWIFTGalaxy(SWIFTDataset):
                             setattr(
                                 new_named_columns_helper._named_column_dataset,
                                 f"_{named_column}",
-                                data[mask.mask(sg)],
+                                data[mask.mask],
                             )
                 else:
                     data = getattr(
@@ -1990,7 +1981,7 @@ class SWIFTGalaxy(SWIFTDataset):
                     )
                     if data is not None:
                         setattr(
-                            new_particle_dataset_helper, field_name, data[mask.mask(sg)]
+                            new_particle_dataset_helper, field_name, data[mask.mask]
                         )
             # cartesian_coordinates return a reference to coordinates on-the-fly:
             # no need to initialise here.
@@ -1998,29 +1989,25 @@ class SWIFTGalaxy(SWIFTDataset):
                 new_particle_dataset_helper._spherical_coordinates = dict()
                 for c in ("_r", "_theta", "_phi"):
                     new_particle_dataset_helper._spherical_coordinates[c] = (
-                        particle_dataset_helper._spherical_coordinates[c][mask.mask(sg)]
+                        particle_dataset_helper._spherical_coordinates[c][mask.mask]
                     )
             if particle_dataset_helper._spherical_velocities is not None:
                 new_particle_dataset_helper._spherical_velocities = dict()
                 for c in ("_v_r", "_v_t", "_v_p"):
                     new_particle_dataset_helper._spherical_velocities[c] = (
-                        particle_dataset_helper._spherical_velocities[c][mask.mask(sg)]
+                        particle_dataset_helper._spherical_velocities[c][mask.mask]
                     )
             if particle_dataset_helper._cylindrical_coordinates is not None:
                 new_particle_dataset_helper._cylindrical_coordinates = dict()
                 for c in ("_rho", "_phi", "_z"):
                     new_particle_dataset_helper._cylindrical_coordinates[c] = (
-                        particle_dataset_helper._cylindrical_coordinates[c][
-                            mask.mask(sg)
-                        ]
+                        particle_dataset_helper._cylindrical_coordinates[c][mask.mask]
                     )
             if particle_dataset_helper._cylindrical_velocities is not None:
                 new_particle_dataset_helper._cylindrical_velocities = dict()
                 for c in ("_v_rho", "_v_phi", "_v_z"):
                     new_particle_dataset_helper._cylindrical_velocities[c] = (
-                        particle_dataset_helper._cylindrical_velocities[c][
-                            mask.mask(sg)
-                        ]
+                        particle_dataset_helper._cylindrical_velocities[c][mask.mask]
                     )
         return sg
 

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -1927,7 +1927,7 @@ class SWIFTGalaxy(SWIFTDataset):
             mask = getattr(
                 mask_collection,
                 particle_name,
-                LazyMask(mask=Ellipsis, mask_type=particle_name),
+                LazyMask(mask=Ellipsis),
             )
             getattr(sg, particle_name)._mask_dataset(mask)
             for field_name in particle_metadata.field_names:

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -873,11 +873,6 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
         particle_metadata = getattr(
             self._particle_dataset.metadata, f"{particle_name}_properties"
         )
-        # force old mask evaluation to ensure any data loaded during evaluation
-        # are in memory and have the old mask applied, if any:
-        old_mask = getattr(self._swiftgalaxy._extra_mask, particle_name)
-        if old_mask is not None:
-            old_mask._evaluate()
         # apply the new mask to any data already in memory:
         for field_name in particle_metadata.field_names:
             if self._is_namedcolumns(field_name):
@@ -902,26 +897,6 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
                 )
         # also the derived coordinates, if any:
         self._mask_derived_coordinates(mask)
-        if getattr(self._swiftgalaxy._extra_mask, particle_name) is None:
-            setattr(self._swiftgalaxy._extra_mask, particle_name, mask)
-        else:
-            if self._swiftgalaxy._spatial_mask is None:
-                # get a count of particles in the box
-                num_part = getattr(self.metadata, f"n_{particle_metadata.group_name}")
-            else:
-                # get a count of particles in the spatial mask region
-                num_part = np.sum(
-                    self._swiftgalaxy._spatial_mask.get_masked_counts_offsets()[0][
-                        particle_name
-                    ]
-                )
-            # need to convert to an integer mask to combine
-            # (boolean is insufficient in case of re-ordering masks)
-            setattr(
-                self._swiftgalaxy._extra_mask,
-                particle_name,
-                LazyMask(mask=np.arange(num_part, dtype=int)[old_mask.mask][mask.mask]),
-            )
         return
 
     def _apply_transforms(self, data: cosmo_array, dataset_name: str) -> cosmo_array:
@@ -1951,12 +1926,12 @@ class SWIFTGalaxy(SWIFTDataset):
             particle_metadata = getattr(sg.metadata, f"{particle_name}_properties")
             particle_dataset_helper = getattr(self, particle_name)
             new_particle_dataset_helper = getattr(sg, particle_name)
-            if mask_collection is not None:
-                mask = getattr(mask_collection, particle_name)
-                if mask is None:
-                    mask = LazyMask(mask=Ellipsis)
-            else:
-                mask = LazyMask(mask=Ellipsis)
+            mask = (
+                getattr(mask_collection, particle_name)
+                if mask_collection is not None
+                and getattr(mask_collection, particle_name) is not None
+                else LazyMask(mask=Ellipsis)
+            )
             getattr(sg, particle_name)._mask_dataset(mask)
             for field_name in particle_metadata.field_names:
                 if particle_dataset_helper._is_namedcolumns(field_name):
@@ -2009,6 +1984,12 @@ class SWIFTGalaxy(SWIFTDataset):
                     new_particle_dataset_helper._cylindrical_velocities[c] = (
                         particle_dataset_helper._cylindrical_velocities[c][mask.mask]
                     )
+        if mask_collection is not None and sg._extra_mask is not None:
+            sg._extra_mask = sg._extra_mask.combine(mask_collection)
+        elif mask_collection is not None:
+            sg._extra_mask = mask_collection
+        if sg._extra_mask is not None:
+            sg._extra_mask._update_sg(sg)
         return sg
 
     def rotate(self, rotation: Rotation) -> None:
@@ -2359,6 +2340,10 @@ class SWIFTGalaxy(SWIFTDataset):
             mask = getattr(mask_collection, particle_name)
             if mask is not None:
                 getattr(self, particle_name)._mask_dataset(mask)
+        if self._extra_mask is not None:
+            self._extra_mask = self._extra_mask.combine(mask_collection)
+        else:
+            self._extra_mask = mask_collection
         return
 
     def _append_to_coordinate_like_transform(

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -802,13 +802,9 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
             A (possibly masked) copy of the
             :class:`~swiftgalaxy.reader._SWIFTGroupDatasetHelper` object.
         """
-        mask_collection = MaskCollection(
-            **{
-                k: Ellipsis if k != self.group_name else mask
-                for k in self.metadata.present_group_names
-            }
+        mask_collection = MaskCollection._from_mask_types_and_values(
+            self.metadata.present_group_names, sg=self, masks={self.group_name: mask}
         )
-        mask_collection._update_sg(self)
         return getattr(
             self._swiftgalaxy._data_copy(mask_collection=mask_collection),
             self.group_name,
@@ -1667,13 +1663,12 @@ class SWIFTGalaxy(SWIFTDataset):
                     ),
                 )
         if self.halo_catalogue is not None:
-            # in server mode we don't have a halo_catalogue yet
             self._extra_mask = self.halo_catalogue._get_extra_mask(self)
         else:
-            self._extra_mask = MaskCollection(
-                **{k: Ellipsis for k in self.metadata.present_group_names}
+            # in server mode we don't have a halo_catalogue yet
+            self._extra_mask = MaskCollection._blank_from_mask_types(
+                self.metadata.present_group_names, sg=self
             )
-            self._extra_mask._update_sg(self)
 
         if auto_recentre and self.halo_catalogue is not None:
             self.recentre(self.halo_catalogue.centre)
@@ -1791,10 +1786,9 @@ class SWIFTGalaxy(SWIFTDataset):
         if _extra_mask is not None:
             sg._extra_mask = _extra_mask
         else:
-            sg._extra_mask = MaskCollection(
-                **{k: Ellipsis for k in sg.metadata.present_group_names}
+            sg._extra_mask = MaskCollection._blank_from_mask_types(
+                sg.metadata.present_group_names, sg=sg
             )
-        sg._extra_mask._update_sg(sg)
         if _coordinate_like_transform is not None:
             sg._coordinate_like_transform = _coordinate_like_transform
         if _velocity_like_transform is not None:
@@ -1988,9 +1982,7 @@ class SWIFTGalaxy(SWIFTDataset):
                         particle_dataset_helper._cylindrical_velocities[c][mask.mask]
                     )
         if mask_collection is not None:
-            mask_collection._update_sg(sg)
             sg._extra_mask = sg._extra_mask.combine(mask_collection)
-        sg._extra_mask._update_sg(sg)
         return sg
 
     def rotate(self, rotation: Rotation) -> None:

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -1984,12 +1984,10 @@ class SWIFTGalaxy(SWIFTDataset):
                     new_particle_dataset_helper._cylindrical_velocities[c] = (
                         particle_dataset_helper._cylindrical_velocities[c][mask.mask]
                     )
-        if mask_collection is not None and sg._extra_mask is not None:
+        assert sg._extra_mask is not None
+        if mask_collection is not None:
             sg._extra_mask = sg._extra_mask.combine(mask_collection)
-        elif mask_collection is not None:
-            sg._extra_mask = mask_collection
-        if sg._extra_mask is not None:
-            sg._extra_mask._update_sg(sg)
+        sg._extra_mask._update_sg(sg)
         return sg
 
     def rotate(self, rotation: Rotation) -> None:
@@ -2340,10 +2338,8 @@ class SWIFTGalaxy(SWIFTDataset):
             mask = getattr(mask_collection, particle_name)
             if mask is not None:
                 getattr(self, particle_name)._mask_dataset(mask)
-        if self._extra_mask is not None:
-            self._extra_mask = self._extra_mask.combine(mask_collection)
-        else:
-            self._extra_mask = mask_collection
+        assert self._extra_mask is not None
+        self._extra_mask = self._extra_mask.combine(mask_collection)
         return
 
     def _append_to_coordinate_like_transform(

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -804,10 +804,11 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
         """
         mask_collection = MaskCollection(
             **{
-                k: None if k != self.group_name else mask
+                k: Ellipsis if k != self.group_name else mask
                 for k in self.metadata.present_group_names
             }
         )
+        mask_collection._update_sg(self)
         return getattr(
             self._swiftgalaxy._data_copy(mask_collection=mask_collection),
             self.group_name,
@@ -851,9 +852,7 @@ class _SWIFTGroupDatasetHelper(__SWIFTGroupDataset):
             The data with any masks applied.
         """
         mask = getattr(self._swiftgalaxy._extra_mask, self._particle_dataset.group_name)
-        if mask is not None:
-            return data[mask.mask]
-        return data
+        return data[mask.mask]
 
     def _mask_dataset(self, mask: LazyMask) -> None:
         """
@@ -1672,11 +1671,9 @@ class SWIFTGalaxy(SWIFTDataset):
             self._extra_mask = self.halo_catalogue._get_extra_mask(self)
         else:
             self._extra_mask = MaskCollection(
-                **{
-                    k: LazyMask(mask=Ellipsis, sg=self)
-                    for k in self.metadata.present_group_names
-                }
+                **{k: Ellipsis for k in self.metadata.present_group_names}
             )
+            self._extra_mask._update_sg(self)
 
         if auto_recentre and self.halo_catalogue is not None:
             self.recentre(self.halo_catalogue.centre)
@@ -1793,7 +1790,11 @@ class SWIFTGalaxy(SWIFTDataset):
         )
         if _extra_mask is not None:
             sg._extra_mask = _extra_mask
-            sg._extra_mask._update_sg(sg)
+        else:
+            sg._extra_mask = MaskCollection(
+                **{k: Ellipsis for k in sg.metadata.present_group_names}
+            )
+        sg._extra_mask._update_sg(sg)
         if _coordinate_like_transform is not None:
             sg._coordinate_like_transform = _coordinate_like_transform
         if _velocity_like_transform is not None:
@@ -1929,11 +1930,10 @@ class SWIFTGalaxy(SWIFTDataset):
             particle_metadata = getattr(sg.metadata, f"{particle_name}_properties")
             particle_dataset_helper = getattr(self, particle_name)
             new_particle_dataset_helper = getattr(sg, particle_name)
-            mask = (
-                getattr(mask_collection, particle_name)
-                if mask_collection is not None
-                and getattr(mask_collection, particle_name) is not None
-                else LazyMask(mask=Ellipsis)
+            mask = getattr(
+                mask_collection,
+                particle_name,
+                LazyMask(mask=Ellipsis, sg=sg, mask_type=particle_name),
             )
             getattr(sg, particle_name)._mask_dataset(mask)
             for field_name in particle_metadata.field_names:
@@ -2338,7 +2338,7 @@ class SWIFTGalaxy(SWIFTDataset):
             them from the :class:`swiftgalaxy.masks.MaskCollection`.
         """
         for particle_name in self.metadata.present_group_names:
-            mask = getattr(mask_collection, particle_name)
+            mask = getattr(mask_collection, particle_name, None)
             if mask is not None:
                 getattr(self, particle_name)._mask_dataset(mask)
         assert self._extra_mask is not None

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -1978,7 +1978,7 @@ class SWIFTGalaxy(SWIFTDataset):
                         particle_dataset_helper._cylindrical_velocities[c][mask.mask]
                     )
         if mask_collection is not None:
-            sg._extra_mask = sg._extra_mask.combine(mask_collection, sg=sg)
+            sg._extra_mask = sg._extra_mask.combined_with(mask_collection, sg=sg)
         return sg
 
     def rotate(self, rotation: Rotation) -> None:
@@ -2328,7 +2328,7 @@ class SWIFTGalaxy(SWIFTDataset):
         for particle_name in self.metadata.present_group_names:
             if (mask := getattr(mask_collection, particle_name, None)) is not None:
                 getattr(self, particle_name)._mask_dataset(mask)
-        self._extra_mask = self._extra_mask.combine(mask_collection, sg=self)
+        self._extra_mask = self._extra_mask.combined_with(mask_collection, sg=self)
         return
 
     def _append_to_coordinate_like_transform(

--- a/swiftgalaxy/reader.py
+++ b/swiftgalaxy/reader.py
@@ -1924,11 +1924,7 @@ class SWIFTGalaxy(SWIFTDataset):
             particle_metadata = getattr(sg.metadata, f"{particle_name}_properties")
             particle_dataset_helper = getattr(self, particle_name)
             new_particle_dataset_helper = getattr(sg, particle_name)
-            mask = getattr(
-                mask_collection,
-                particle_name,
-                LazyMask(mask=Ellipsis),
-            )
+            mask = getattr(mask_collection, particle_name, LazyMask(mask=Ellipsis))
             getattr(sg, particle_name)._mask_dataset(mask)
             for field_name in particle_metadata.field_names:
                 if particle_dataset_helper._is_namedcolumns(field_name):
@@ -2330,10 +2326,8 @@ class SWIFTGalaxy(SWIFTDataset):
             them from the :class:`swiftgalaxy.masks.MaskCollection`.
         """
         for particle_name in self.metadata.present_group_names:
-            mask = getattr(mask_collection, particle_name, None)
-            if mask is not None:
+            if (mask := getattr(mask_collection, particle_name, None)) is not None:
                 getattr(self, particle_name)._mask_dataset(mask)
-        assert self._extra_mask is not None
         self._extra_mask = self._extra_mask.combine(mask_collection, sg=self)
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1621,14 +1621,9 @@ def lm() -> LazyMask:
         A lazy mask.
     """
 
-    def mf(arg: None) -> np.ndarray:
+    def mf() -> np.ndarray:
         """
         Create a simple mask function.
-
-        Parameters
-        ----------
-        arg : None
-            An argument is required, but for this test object its value is unused.
 
         Returns
         -------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -533,6 +533,37 @@ def sgs_caesar(
 
 
 @pytest.fixture(scope="function")
+def sg_no_hf(tmp_path_factory: TempPathFactory) -> SWIFTGalaxy:
+    """
+    Make a :class:`~swiftgalaxy.reader.SWIFTGalaxy`.
+
+    With no halo catalogue. Useful to test no mask whatsoever.
+
+    Parameters
+    ----------
+    tmp_path_factory : TempPathFactory
+        Pytest fixture to create temporary directories.
+
+    Yields
+    ------
+    ~swiftgalaxy.reader.SWIFTGalaxy
+        A :class:`~swiftgalaxy.reader.SWIFTGalaxy` with no halo catalogue
+    """
+    tp = tmp_path_factory.mktemp(_toysnap_filename.parent)
+    toysnap_filename = tp / _toysnap_filename.name
+    _create_toysnap(snapfile=toysnap_filename)
+
+    yield SWIFTGalaxy(
+        toysnap_filename,
+        None,  # no halo_catalogue is easiest way to get no mask
+        transforms_like_coordinates={"coordinates", "extra_coordinates"},
+        transforms_like_velocities={"velocities", "extra_velocities"},
+    )
+
+    _remove_toysnap(snapfile=toysnap_filename)
+
+
+@pytest.fixture(scope="function")
 def soap(tmp_path_factory: TempPathFactory) -> SOAP:
     """
     Make a :class:`~swiftgalaxy.halo_catalogues.SOAP` catalogue.

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -177,20 +177,20 @@ class TestCopyMaskCollection:
                 assert comparison
             else:
                 assert all(comparison)
-        assert all(mc.lazy_evaluated.mask(None) == mc_copy.lazy_evaluated.mask(None))
-        assert mc.lazy_unevaluated.mask(None) == mc_copy.lazy_unevaluated.mask(None)
+        assert all(mc.lazy_evaluated.mask == mc_copy.lazy_evaluated.mask)
+        assert mc.lazy_unevaluated.mask == mc_copy.lazy_unevaluated.mask
 
 
 class TestCopyHaloCatalogue:
     """Test that halo catalogue classes can be copied."""
 
-    def test_copy(self, web_hf):
+    def test_copy_web_hf(self, web_hf):
         """Test that we can copy a halo catalogue object."""
         c = copy(web_hf)
         assert isinstance(c, type(web_hf))
         assert c is not web_hf
 
-    def test_deepcopy_sg(self, web_sg):
+    def test_deepcopy_web_sg(self, web_sg):
         """
         Test that we can deepcopy a swiftgalaxy object.
 

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -174,7 +174,7 @@ class TestCopyMaskCollection:
             stars=None,
             black_holes=np.arange(3),
             lazy_evaluated=LazyMask(mask=np.ones(100, dtype=bool)),
-            lazy_unevaluated=LazyMask(mask_function=lambda x: np.s_[:20]),
+            lazy_unevaluated=LazyMask(mask_function=lambda: np.s_[:20]),
         )
         mc_copy = deepcopy(mc)
         assert set(mc_copy.__dict__.keys()) == set(mc.__dict__.keys())

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -158,7 +158,7 @@ class TestCopyMaskCollection:
             black_holes=np.arange(3),
         )
         mc_copy = copy(mc)
-        assert set(mc_copy.__dict__.keys()) == set(mc.__dict__.keys())
+        assert set(mc_copy._masks.keys()) == set(mc._masks.keys())
         for k in ("gas", "dark_matter", "stars", "black_holes"):
             comparison = getattr(mc, k) == getattr(mc_copy, k)
             if type(comparison) is bool:
@@ -173,11 +173,15 @@ class TestCopyMaskCollection:
             dark_matter=np.s_[:20],
             stars=None,
             black_holes=np.arange(3),
-            lazy_evaluated=LazyMask(mask=np.ones(100, dtype=bool)),
-            lazy_unevaluated=LazyMask(mask_function=lambda: np.s_[:20]),
+            lazy_evaluated=LazyMask(
+                mask=np.ones(100, dtype=bool), mask_type="lazy_evaluated"
+            ),
+            lazy_unevaluated=LazyMask(
+                mask_function=lambda: np.s_[:20], mask_type="lazy_unevaluated"
+            ),
         )
         mc_copy = deepcopy(mc)
-        assert set(mc_copy.__dict__.keys()) == set(mc.__dict__.keys())
+        assert set(mc_copy._masks.keys()) == set(mc._masks.keys())
         for k in ("gas", "dark_matter", "stars", "black_holes"):
             comparison = getattr(mc, k) == getattr(mc_copy, k)
             if type(comparison) is bool:
@@ -186,6 +190,10 @@ class TestCopyMaskCollection:
                 assert all(comparison)
         assert all(mc.lazy_evaluated.mask == mc_copy.lazy_evaluated.mask)
         assert mc.lazy_unevaluated.mask == mc_copy.lazy_unevaluated.mask
+        for k in mc._masks.keys():
+            assert getattr(mc, k)._mask_type == k
+        for k in mc_copy._masks.keys():
+            assert getattr(mc_copy, k)._mask_type == k
 
 
 class TestCopyHaloCatalogue:

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -31,11 +31,10 @@ class TestCopySWIFTGalaxy:
 
     def test_copy_sg_without_mask(self, sg_no_hf):
         """Test that we can handle copying when there is no mask."""
-        print(sg_no_hf._extra_mask)
         copy_hf = deepcopy(sg_no_hf)
         assert copy_hf.mask is None
         for ptype in copy_hf.metadata.present_group_names:
-            assert getattr(copy_hf._extra_mask, ptype) is None
+            assert getattr(copy_hf._extra_mask, ptype).mask is Ellipsis
 
     @pytest.mark.parametrize("derived_coords_initialized", [True, False])
     def test_deepcopy_sg(self, sg, derived_coords_initialized):

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -29,6 +29,14 @@ class TestCopySWIFTGalaxy:
             is None
         )
 
+    def test_copy_sg_without_mask(self, sg_no_hf):
+        """Test that we can handle copying when there is no mask."""
+        print(sg_no_hf._extra_mask)
+        copy_hf = deepcopy(sg_no_hf)
+        assert copy_hf.mask is None
+        for ptype in copy_hf.metadata.present_group_names:
+            assert getattr(copy_hf._extra_mask, ptype) is None
+
     @pytest.mark.parametrize("derived_coords_initialized", [True, False])
     def test_deepcopy_sg(self, sg, derived_coords_initialized):
         """Test that dataset arrays get copied on deep copy."""

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -173,12 +173,8 @@ class TestCopyMaskCollection:
             dark_matter=np.s_[:20],
             stars=None,
             black_holes=np.arange(3),
-            lazy_evaluated=LazyMask(
-                mask=np.ones(100, dtype=bool), mask_type="lazy_evaluated"
-            ),
-            lazy_unevaluated=LazyMask(
-                mask_function=lambda: np.s_[:20], mask_type="lazy_unevaluated"
-            ),
+            lazy_evaluated=LazyMask(mask=np.ones(100, dtype=bool)),
+            lazy_unevaluated=LazyMask(mask_function=lambda: np.s_[:20]),
         )
         mc_copy = deepcopy(mc)
         assert set(mc_copy._masks.keys()) == set(mc._masks.keys())
@@ -190,10 +186,6 @@ class TestCopyMaskCollection:
                 assert all(comparison)
         assert all(mc.lazy_evaluated.mask == mc_copy.lazy_evaluated.mask)
         assert mc.lazy_unevaluated.mask == mc_copy.lazy_unevaluated.mask
-        for k in mc._masks.keys():
-            assert getattr(mc, k)._mask_type == k
-        for k in mc_copy._masks.keys():
-            assert getattr(mc_copy, k)._mask_type == k
 
 
 class TestCopyHaloCatalogue:

--- a/tests/test_halo_catalogues.py
+++ b/tests/test_halo_catalogues.py
@@ -208,7 +208,7 @@ class TestHaloCatalogues:
         sg = SWIFTGalaxy(toysnap["toysnap_filename"], hf)
         generated_extra_mask = sg._extra_mask
         for particle_type in _present_particle_types.values():
-            assert getattr(generated_extra_mask, particle_type) is None
+            assert getattr(generated_extra_mask, particle_type).mask is Ellipsis
 
     def test_get_user_extra_mask(self, hf, toysnap):
         """Check that extra masks of different kinds have the right shape or type."""
@@ -221,19 +221,19 @@ class TestHaloCatalogues:
         sg = SWIFTGalaxy(toysnap["toysnap_filename"], hf)
         generated_extra_mask = sg._extra_mask
         for particle_type in _present_particle_types.values():
-            if getattr(generated_extra_mask, particle_type) is None:
+            if getattr(generated_extra_mask, particle_type).mask is Ellipsis:
                 assert (
-                    dict(gas=100, dark_matter=None, stars=100, black_holes=_n_bh_1)[
+                    dict(gas=100, dark_matter=Ellipsis, stars=100, black_holes=_n_bh_1)[
                         particle_type
                     ]
-                    is None
+                    is Ellipsis
                 )
             else:
                 assert (
                     getattr(generated_extra_mask, particle_type).mask.sum()
-                    == dict(gas=100, dark_matter=None, stars=100, black_holes=_n_bh_1)[
-                        particle_type
-                    ]
+                    == dict(
+                        gas=100, dark_matter=Ellipsis, stars=100, black_holes=_n_bh_1
+                    )[particle_type]
                 )
 
     def test_centre(self, hf):
@@ -653,7 +653,7 @@ class TestVelociraptorWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable(sg, ptype)
+                getattr(sg._extra_mask, ptype)._make_combinable()
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask
@@ -893,7 +893,7 @@ class TestCaesarWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable(sg, ptype)
+                getattr(sg._extra_mask, ptype)._make_combinable()
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask
@@ -1354,7 +1354,7 @@ class TestSOAPWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable(sg, ptype)
+                getattr(sg._extra_mask, ptype)._make_combinable()
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask

--- a/tests/test_halo_catalogues.py
+++ b/tests/test_halo_catalogues.py
@@ -653,7 +653,7 @@ class TestVelociraptorWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable(sg)
+                getattr(sg._extra_mask, ptype)._make_combinable(sg=sg, mask_type=ptype)
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask
@@ -893,7 +893,7 @@ class TestCaesarWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable(sg)
+                getattr(sg._extra_mask, ptype)._make_combinable(sg=sg, mask_type=ptype)
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask
@@ -1354,7 +1354,7 @@ class TestSOAPWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable(sg)
+                getattr(sg._extra_mask, ptype)._make_combinable(sg=sg, mask_type=ptype)
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask

--- a/tests/test_halo_catalogues.py
+++ b/tests/test_halo_catalogues.py
@@ -653,7 +653,7 @@ class TestVelociraptorWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable()
+                getattr(sg._extra_mask, ptype)._make_combinable(sg)
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask
@@ -893,7 +893,7 @@ class TestCaesarWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable()
+                getattr(sg._extra_mask, ptype)._make_combinable(sg)
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask
@@ -1354,7 +1354,7 @@ class TestSOAPWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable()
+                getattr(sg._extra_mask, ptype)._make_combinable(sg)
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask

--- a/tests/test_halo_catalogues.py
+++ b/tests/test_halo_catalogues.py
@@ -188,11 +188,11 @@ class TestHaloCatalogues:
         for particle_type in _present_particle_types.values():
             if expected_shape[particle_type] is not None:
                 assert (
-                    getattr(generated_extra_mask, particle_type).mask(sg).shape
+                    getattr(generated_extra_mask, particle_type).mask.shape
                     == expected_shape[particle_type]
                 )
                 assert (
-                    getattr(generated_extra_mask, particle_type).mask(sg).sum()
+                    getattr(generated_extra_mask, particle_type).mask.sum()
                     == dict(
                         gas=_n_g_1,
                         dark_matter=_n_dm_1,
@@ -230,7 +230,7 @@ class TestHaloCatalogues:
                 )
             else:
                 assert (
-                    getattr(generated_extra_mask, particle_type).mask(sg).sum()
+                    getattr(generated_extra_mask, particle_type).mask.sum()
                     == dict(gas=100, dark_matter=None, stars=100, black_holes=_n_bh_1)[
                         particle_type
                     ]
@@ -418,11 +418,11 @@ class TestHaloCataloguesMulti:
         for particle_type in _present_particle_types.values():
             if expected_shape[particle_type] is not None:
                 assert (
-                    getattr(generated_extra_mask, particle_type).mask(sg).shape
+                    getattr(generated_extra_mask, particle_type).mask.shape
                     == expected_shape[particle_type]
                 )
                 assert (
-                    getattr(generated_extra_mask, particle_type).mask(sg).sum()
+                    getattr(generated_extra_mask, particle_type).mask.sum()
                     == dict(
                         gas=_n_g_1,
                         dark_matter=_n_dm_1,
@@ -654,8 +654,8 @@ class TestVelociraptorWithSWIFTGalaxy:
             )
             for ptype in _present_particle_types.values():
                 assert np.all(
-                    getattr(sg_from_sgs._extra_mask, ptype).mask(sg_from_sgs)
-                    == getattr(sg._extra_mask, ptype).mask(sg)
+                    getattr(sg_from_sgs._extra_mask, ptype).mask
+                    == getattr(sg._extra_mask, ptype).mask
                 )
 
     def test_lazy_masking_sg(self, sg_vr):
@@ -893,13 +893,14 @@ class TestCaesarWithSWIFTGalaxy:
             )
             for ptype in _present_particle_types.values():
                 if isinstance(getattr(sg_from_sgs._extra_mask, ptype), slice):
-                    assert getattr(sg_from_sgs._extra_mask, ptype).mask(
-                        sg_from_sgs
-                    ) == getattr(sg._extra_mask, ptype).mask(sg)
+                    assert (
+                        getattr(sg_from_sgs._extra_mask, ptype).mask
+                        == getattr(sg._extra_mask, ptype).mask
+                    )
                 else:
                     assert np.all(
-                        getattr(sg_from_sgs._extra_mask, ptype).mask(sg_from_sgs)
-                        == getattr(sg._extra_mask, ptype).mask(sg)
+                        getattr(sg_from_sgs._extra_mask, ptype).mask
+                        == getattr(sg._extra_mask, ptype).mask
                     )
 
     @pytest.mark.parametrize("group_type", ["halo", "galaxy"])
@@ -925,10 +926,10 @@ class TestCaesarWithSWIFTGalaxy:
                 toysnap["toysnap_filename"],
                 Caesar(toycaesar_filename, group_type=group_type, group_index=0),
             )
-            assert sg._extra_mask.gas.mask(sg) == np.s_[:0]
-            assert sg._extra_mask.stars.mask(sg) == np.s_[:0]
-            assert sg._extra_mask.dark_matter.mask(sg) == np.s_[:0]
-            assert sg._extra_mask.black_holes.mask(sg) == np.s_[:0]
+            assert sg._extra_mask.gas.mask == np.s_[:0]
+            assert sg._extra_mask.stars.mask == np.s_[:0]
+            assert sg._extra_mask.dark_matter.mask == np.s_[:0]
+            assert sg._extra_mask.black_holes.mask == np.s_[:0]
         finally:
             _remove_toycaesar(filename=toycaesar_filename)
 
@@ -1358,8 +1359,8 @@ class TestSOAPWithSWIFTGalaxy:
             )
             for ptype in _present_particle_types.values():
                 assert np.all(
-                    getattr(sg_from_sgs._extra_mask, ptype).mask(sg_from_sgs)
-                    == getattr(sg._extra_mask, ptype).mask(sg)
+                    getattr(sg_from_sgs._extra_mask, ptype).mask
+                    == getattr(sg._extra_mask, ptype).mask
                 )
 
     def test_lazy_masking_sg(self, sg_soap):

--- a/tests/test_halo_catalogues.py
+++ b/tests/test_halo_catalogues.py
@@ -653,6 +653,7 @@ class TestVelociraptorWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
+                getattr(sg._extra_mask, ptype)._make_combinable(sg, ptype)
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask
@@ -892,16 +893,11 @@ class TestCaesarWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
-                if isinstance(getattr(sg_from_sgs._extra_mask, ptype), slice):
-                    assert (
-                        getattr(sg_from_sgs._extra_mask, ptype).mask
-                        == getattr(sg._extra_mask, ptype).mask
-                    )
-                else:
-                    assert np.all(
-                        getattr(sg_from_sgs._extra_mask, ptype).mask
-                        == getattr(sg._extra_mask, ptype).mask
-                    )
+                getattr(sg._extra_mask, ptype)._make_combinable(sg, ptype)
+                assert np.all(
+                    getattr(sg_from_sgs._extra_mask, ptype).mask
+                    == getattr(sg._extra_mask, ptype).mask
+                )
 
     @pytest.mark.parametrize("group_type", ["halo", "galaxy"])
     def test_incomplete_catalogue(self, toysnap, group_type):
@@ -1358,6 +1354,7 @@ class TestSOAPWithSWIFTGalaxy:
                 ),
             )
             for ptype in _present_particle_types.values():
+                getattr(sg._extra_mask, ptype)._make_combinable(sg, ptype)
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -238,7 +238,7 @@ class TestSWIFTGalaxies:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable(sg)
+                getattr(sg._extra_mask, ptype)._make_combinable(sg=sg, mask_type=ptype)
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -238,7 +238,7 @@ class TestSWIFTGalaxies:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable(sg, ptype)
+                getattr(sg._extra_mask, ptype)._make_combinable()
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -238,7 +238,7 @@ class TestSWIFTGalaxies:
                 ),
             )
             for ptype in _present_particle_types.values():
-                getattr(sg._extra_mask, ptype)._make_combinable()
+                getattr(sg._extra_mask, ptype)._make_combinable(sg)
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -238,6 +238,7 @@ class TestSWIFTGalaxies:
                 ),
             )
             for ptype in _present_particle_types.values():
+                getattr(sg._extra_mask, ptype)._make_combinable(sg, ptype)
                 assert np.all(
                     getattr(sg_from_sgs._extra_mask, ptype).mask
                     == getattr(sg._extra_mask, ptype).mask

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -239,8 +239,8 @@ class TestSWIFTGalaxies:
             )
             for ptype in _present_particle_types.values():
                 assert np.all(
-                    getattr(sg_from_sgs._extra_mask, ptype).mask(sg_from_sgs)
-                    == getattr(sg._extra_mask, ptype).mask(sg)
+                    getattr(sg_from_sgs._extra_mask, ptype).mask
+                    == getattr(sg._extra_mask, ptype).mask
                 )
             count += 1
         assert count == len(sgs.halo_catalogue.index)

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -532,3 +532,12 @@ class TestLazyMask:
         lm = LazyMask(mask=None)
         assert lm == lm
         assert not lm != lm
+
+    def test_combine_without_sg_fails(self):
+        """Check that trying to combine masks without a SWIFTGalaxy reference fails."""
+        lm1 = LazyMask(mask=None)
+        lm2 = LazyMask(mask=None)
+        with pytest.raises(
+            ValueError, match="LazyMask must have associated SWIFTGalaxy"
+        ):
+            lm1._combined_with(lm2)

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -6,12 +6,9 @@ import numpy as np
 import unyt as u
 from unyt.testing import assert_allclose_units
 from swiftsimio import cosmo_quantity
-from swiftgalaxy import SWIFTGalaxy, MaskCollection
+from swiftgalaxy import MaskCollection
 from swiftgalaxy.demo_data import (
     ToyHF,
-    _create_toysnap,
-    _remove_toysnap,
-    _toysnap_filename,
     _present_particle_types,
     _n_g_all,
     _n_dm_all,
@@ -100,44 +97,31 @@ class TestMaskingSWIFTGalaxy:
             neutral_before[mask], neutral, rtol=reltol_nd, atol=abstol_nd
         )
 
-    def test_mask_without_spatial_mask(self, tmp_path_factory):
+    def test_mask_without_spatial_mask(self, sg_no_hf):
         """
         Check that if we have no masks we read everything in the box (and warn about it).
 
         Then that we can still apply an extra mask, and a second one (there's specific
         logic for applying two consecutively).
         """
-        toysnap_filename = (
-            tmp_path_factory.mktemp(_toysnap_filename.parent) / _toysnap_filename.name
-        )
-        try:
-            _create_toysnap(snapfile=toysnap_filename)
-            sg = SWIFTGalaxy(
-                toysnap_filename,
-                None,  # no halo_catalogue is easiest way to get no mask
-                transforms_like_coordinates={"coordinates", "extra_coordinates"},
-                transforms_like_velocities={"velocities", "extra_velocities"},
-            )
-            # check that extra mask is blank for all particle types:
-            assert sg._extra_mask.gas is None
-            assert sg._extra_mask.dark_matter is None
-            assert sg._extra_mask.stars is None
-            assert sg._extra_mask.black_holes is None
-            # check that cell mask is blank for all particle types:
-            assert sg._spatial_mask is None
-            # check that we read all the particles:
-            assert sg.gas.masses.size == _n_g_all
-            assert sg.dark_matter.masses.size == _n_dm_all
-            assert sg.stars.masses.size == _n_s_all
-            assert sg.black_holes.masses.size == _n_bh_all
-            # now apply an extra mask
-            sg.mask_particles(MaskCollection(gas=np.s_[:1000]))
-            assert sg.gas.masses.size == 1000
-            # and the second consecutive one
-            sg.mask_particles(MaskCollection(gas=np.s_[:100]))
-            assert sg.gas.masses.size == 100
-        finally:
-            _remove_toysnap(snapfile=toysnap_filename)
+        # check that extra mask is blank for all particle types:
+        assert sg_no_hf._extra_mask.gas is None
+        assert sg_no_hf._extra_mask.dark_matter is None
+        assert sg_no_hf._extra_mask.stars is None
+        assert sg_no_hf._extra_mask.black_holes is None
+        # check that cell mask is blank for all particle types:
+        assert sg_no_hf._spatial_mask is None
+        # check that we read all the particles:
+        assert sg_no_hf.gas.masses.size == _n_g_all
+        assert sg_no_hf.dark_matter.masses.size == _n_dm_all
+        assert sg_no_hf.stars.masses.size == _n_s_all
+        assert sg_no_hf.black_holes.masses.size == _n_bh_all
+        # now apply an extra mask
+        sg_no_hf.mask_particles(MaskCollection(gas=np.s_[:1000]))
+        assert sg_no_hf.gas.masses.size == 1000
+        # and the second consecutive one
+        sg_no_hf.mask_particles(MaskCollection(gas=np.s_[:100]))
+        assert sg_no_hf.gas.masses.size == 100
 
     def test_repeated_copy_mask(self, sg_soap):
         """

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -532,3 +532,14 @@ class TestLazyMask:
         lm = LazyMask(mask=None)
         assert lm == lm
         assert not lm != lm
+
+
+class TestMaskCollection:
+    """Tests for the MaskCollection class."""
+
+    def test_warning_for_unexpected_field_in_combining_mask_collections(self, sg):
+        """Check that trying to combine with a collection with extra fields warns."""
+        mc1 = MaskCollection(gas=Ellipsis)
+        mc2 = MaskCollection(gas=Ellipsis, dark_matter=Ellipsis)
+        with pytest.warns(UserWarning, match="Unexpected fields"):
+            mc1.combined_with(mc2, sg=sg)

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -405,9 +405,9 @@ class TestLazyMask:
         """Check that accessing mask triggers evaluation if lazy."""
         assert lm._evaluated is False
         assert not hasattr(lm, "_mask")
-        assert (lm.mask == lm._mask_function(None)).all()
+        assert (lm.mask == lm._mask_function()).all()
         assert lm._evaluated
-        assert (lm._mask == lm._mask_function(None)).all()
+        assert (lm._mask == lm._mask_function()).all()
 
     def test_access_not_lazy(self):
         """Check that accessing the mask works for a non-lazy mask."""
@@ -422,8 +422,8 @@ class TestLazyMask:
         assert not hasattr(lm, "_mask")
         lm._evaluate()
         assert lm._evaluated
-        assert (lm.mask == lm._mask_function(None)).all()
-        assert (lm._mask == lm._mask_function(None)).all()
+        assert (lm.mask == lm._mask_function()).all()
+        assert (lm._mask == lm._mask_function()).all()
 
     def test_trigger_eval_once_only(self):
         """Check that we can't trigger mask evaluation repeatedly."""
@@ -433,14 +433,9 @@ class TestLazyMask:
 
             call_counter: int = 0
 
-            def __call__(self, arg: None):
+            def __call__(self):
                 """
                 Call the class to behave like a simple mask function.
-
-                Parameters
-                ----------
-                arg : None
-                    An argument is required but its value is unused.
 
                 Returns
                 -------
@@ -475,7 +470,7 @@ class TestLazyMask:
         # now copy after evaluating
         lm_evaluated_copy = copy(lm)
         assert lm_evaluated_copy._evaluated
-        assert (lm_evaluated_copy._mask == lm._mask_function(None)).all()
+        assert (lm_evaluated_copy._mask == lm._mask_function()).all()
         assert lm_evaluated_copy._mask_function is lm._mask_function
         # and test a non-lazy mask
         m = np.ones(10, dtype=bool)
@@ -498,7 +493,7 @@ class TestLazyMask:
         # now copy after evaluating
         lm_evaluated_copy = deepcopy(lm)
         assert lm_evaluated_copy._evaluated
-        assert (lm_evaluated_copy._mask == lm._mask_function(None)).all()
+        assert (lm_evaluated_copy._mask == lm._mask_function()).all()
         assert lm_evaluated_copy._mask_function is lm._mask_function
         # and test a non-lazy mask
         m = np.ones(10, dtype=bool)

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -6,7 +6,7 @@ import numpy as np
 import unyt as u
 from unyt.testing import assert_allclose_units
 from swiftsimio import cosmo_quantity
-from swiftgalaxy import MaskCollection
+from swiftgalaxy import MaskCollection, SWIFTGalaxy
 from swiftgalaxy.demo_data import (
     ToyHF,
     _present_particle_types,
@@ -19,6 +19,27 @@ from swiftgalaxy.masks import LazyMask
 
 abstol_nd = 1.0e-4
 reltol_nd = 1.0e-4
+
+
+def assert_no_data_loaded(sg: SWIFTGalaxy) -> None:
+    """
+    Iterate over all datasets and asserts that they are ``None``.
+
+    Parameters
+    ----------
+    sg : ~swiftgalaxy.reader.SWIFTGalaxy
+        The :class:`~swiftgalaxy.reader.SWIFTGalaxy` to check for loaded data.
+
+    Raises
+    ------
+    AssertionError
+        If any datasets are not ``None``.
+    """
+    for ptype in sg.metadata.present_group_names:
+        for field_name in getattr(sg, ptype).group_metadata.field_names:
+            assert (
+                getattr(getattr(sg, ptype)._particle_dataset, f"_{field_name}") is None
+            )
 
 
 class TestMaskingSWIFTGalaxy:
@@ -206,6 +227,28 @@ class TestMaskingSWIFTGalaxy:
         sg_no_hf.mask_particles(MaskCollection(gas=np.s_[::2]))
         sg_no_hf.mask_particles(MaskCollection(gas=np.s_[::2]))
         assert_allclose_units(ids_before_sg_no_hf[::2][::2], sg_no_hf.gas.particle_ids)
+
+    def test_mask_combining_is_lazy(self, sg_soap):
+        """Check that no data loading is triggered by lazy masking."""
+        assert sg_soap.halo_catalogue.extra_mask == "bound_only"
+        # check that setting bound_only mask hasn't triggered any data reads:
+        assert_no_data_loaded(sg_soap)
+        # combine existing lazy mask with a new mask:
+        sg_soap.mask_particles(MaskCollection(gas=np.s_[:100]))
+        # check that applying the new mask hasn't triggered any data reads:
+        assert_no_data_loaded(sg_soap)
+        # also check the copy-masking case
+        new_sg = sg_soap[MaskCollection(dark_matter=np.s_[:100])]
+        assert_no_data_loaded(new_sg)
+        # now check that we can load successfully:
+        sg_soap.gas.group_nr_bound
+        assert (
+            sg_soap.gas.group_nr_bound
+            == sg_soap.halo_catalogue.input_halos.halo_catalogue_index
+        ).all()
+        assert sg_soap.gas.group_nr_bound.size == 100
+        # and check we haven't loaded the DM group IDs, just to be sure:
+        assert sg_soap.dark_matter._particle_dataset._group_nr_bound is None
 
 
 class TestMaskingParticleDatasets:
@@ -533,6 +576,43 @@ class TestLazyMask:
         assert lm == lm
         assert not lm != lm
 
+    def test_make_combinable_evaluated(self, sg):
+        """Test that making a LazyMask 'combinable' results in an integer index array."""
+        lm = LazyMask(np.s_[:10])
+        assert not isinstance(lm.mask, np.ndarray)
+        assert not lm._combinable
+        lm._make_combinable(sg=sg, mask_type="gas")
+        assert lm._evaluated
+        assert isinstance(lm.mask, np.ndarray)
+        assert lm.mask.dtype == int
+        assert lm._combinable
+        assert len(lm.mask) == 10
+
+    def test_make_combinable_unevaluated(self, sg):
+        """Test that making a LazyMask 'combinable' results in an integer index array."""
+        lm = LazyMask(mask_function=lambda: np.s_[:10])
+        assert not lm._combinable
+        lm._make_combinable(sg=sg, mask_type="gas")
+        assert lm._combinable
+        assert not lm._evaluated
+        assert isinstance(lm.mask, np.ndarray)  # triggers evaluation
+        assert lm.mask.dtype == int
+        assert len(lm.mask) == 10
+
+    def test_combined_with(self, sg):
+        """Check that combining two masks results in 'chaining together' the masks."""
+        lm1 = LazyMask(mask=np.s_[::2])
+        lm2 = LazyMask(mask=np.s_[::2])
+        combined_lm = lm1._combined_with(lm2, sg=sg, mask_type="gas")
+        assert isinstance(combined_lm.mask, np.ndarray)
+        assert combined_lm.mask.dtype == int
+        assert sg._spatial_mask is not None
+        # expect length // 4 since we did [::2] twice:
+        assert (
+            combined_lm.mask.size
+            == np.sum(sg._spatial_mask.get_masked_counts_offsets()[0]["gas"]) // 4
+        )
+
 
 class TestMaskCollection:
     """Tests for the MaskCollection class."""
@@ -543,3 +623,52 @@ class TestMaskCollection:
         mc2 = MaskCollection(gas=Ellipsis, dark_matter=Ellipsis)
         with pytest.warns(UserWarning, match="Unexpected fields"):
             mc1.combined_with(mc2, sg=sg)
+
+    def test_blank_from_mask_types(self):
+        """Test that a set of ``Ellipsis`` masks with desired names is created."""
+        mask_types = ("a", "b", "c")
+        mc = MaskCollection._blank_from_mask_types(mask_types)
+        assert len(mc._masks) == len(mask_types)
+        assert set(mc._masks.keys()) == set(mask_types)
+        for k in mask_types:
+            assert getattr(mc, k) == LazyMask(mask=Ellipsis)
+
+    def test_from_mask_types_and_values(self):
+        """Test that a set of masks with all desired names and mask values is created."""
+        mask_types = ("a", "b", "c")
+        values = {"a": np.s_[:10], "c": np.array([True, False], dtype=bool)}
+        mc = MaskCollection._from_mask_types_and_values(mask_types, values)
+        assert len(mc._masks) == len(mask_types)
+        assert set(mc._masks.keys()) == set(mask_types)
+        for k in mask_types:
+            if k in values:
+                assert getattr(mc, k) == LazyMask(mask=values[k])
+            else:
+                assert getattr(mc, k) == LazyMask(mask=Ellipsis)
+
+    def test_mask_not_found(self):
+        """Test that AttributeError is raised when a non-existant mask is requested."""
+        mc = MaskCollection(a=np.s_[:10])
+        assert "b" not in mc._masks.keys()
+        with pytest.raises(
+            AttributeError, match="'MaskCollection' has no attribute 'b'"
+        ):
+            mc.b
+
+    def test_combined_with(self, sg):
+        """Check that combining two masks results in 'chaining together' the masks."""
+        mc1 = MaskCollection(gas=np.s_[:10], dark_matter=np.s_[::2])
+        mc2 = MaskCollection(gas=np.s_[:5], dark_matter=np.s_[::2])
+        combined_mc = mc1.combined_with(mc2, sg=sg)
+        assert isinstance(combined_mc.gas.mask, np.ndarray)
+        assert combined_mc.gas.mask.dtype == int
+        assert combined_mc.gas.mask.size == 5
+        assert isinstance(combined_mc.dark_matter.mask, np.ndarray)
+        assert combined_mc.dark_matter.mask.dtype == int
+        assert sg._spatial_mask is not None
+        # expect length // 4 since we did [::2] twice:
+        assert (
+            combined_mc.dark_matter.mask.size
+            == np.sum(sg._spatial_mask.get_masked_counts_offsets()[0]["dark_matter"])
+            // 4
+        )

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -105,10 +105,10 @@ class TestMaskingSWIFTGalaxy:
         logic for applying two consecutively).
         """
         # check that extra mask is blank for all particle types:
-        assert sg_no_hf._extra_mask.gas is None
-        assert sg_no_hf._extra_mask.dark_matter is None
-        assert sg_no_hf._extra_mask.stars is None
-        assert sg_no_hf._extra_mask.black_holes is None
+        assert sg_no_hf._extra_mask.gas.mask is Ellipsis
+        assert sg_no_hf._extra_mask.dark_matter.mask is Ellipsis
+        assert sg_no_hf._extra_mask.stars.mask is Ellipsis
+        assert sg_no_hf._extra_mask.black_holes.mask is Ellipsis
         # check that cell mask is blank for all particle types:
         assert sg_no_hf._spatial_mask is None
         # check that we read all the particles:
@@ -176,6 +176,36 @@ class TestMaskingSWIFTGalaxy:
                 scale_exponent=1,
             )
         ).all()
+
+    @pytest.mark.parametrize("before_load", (True, False))
+    def test_chained_masking(self, sg, before_load):
+        """
+        Check that we can mask repeatedly.
+
+        Check both the case with (sg) and without (sg_no_hf) a spatial mask.
+        """
+        ids_before_sg = sg.gas.particle_ids
+        if before_load:
+            sg.gas._particle_dataset._particle_ids = None
+            del sg._extra_mask.gas._mask
+            sg._extra_mask.gas._evaluated = False
+        sg.mask_particles(MaskCollection(gas=np.s_[::2]))
+        sg.mask_particles(MaskCollection(gas=np.s_[::2]))
+        assert_allclose_units(ids_before_sg[::2][::2], sg.gas.particle_ids)
+
+    @pytest.mark.parametrize("before_load", (True, False))
+    def test_chained_masking_without_spatial(self, sg_no_hf, before_load):
+        """
+        Check that we can mask repeatedly.
+
+        Check both the case with (sg) and without (sg_no_hf) a spatial mask.
+        """
+        ids_before_sg_no_hf = sg_no_hf.gas.particle_ids
+        if before_load:
+            sg_no_hf.gas._particle_dataset._particle_ids = None
+        sg_no_hf.mask_particles(MaskCollection(gas=np.s_[::2]))
+        sg_no_hf.mask_particles(MaskCollection(gas=np.s_[::2]))
+        assert_allclose_units(ids_before_sg_no_hf[::2][::2], sg_no_hf.gas.particle_ids)
 
 
 class TestMaskingParticleDatasets:

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -532,12 +532,3 @@ class TestLazyMask:
         lm = LazyMask(mask=None)
         assert lm == lm
         assert not lm != lm
-
-    def test_combine_without_sg_fails(self):
-        """Check that trying to combine masks without a SWIFTGalaxy reference fails."""
-        lm1 = LazyMask(mask=None)
-        lm2 = LazyMask(mask=None)
-        with pytest.raises(
-            ValueError, match="LazyMask must have associated SWIFTGalaxy"
-        ):
-            lm1._combined_with(lm2)

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -391,7 +391,7 @@ class TestLazyMask:
         """Check that accessing mask triggers evaluation if lazy."""
         assert lm._evaluated is False
         assert not hasattr(lm, "_mask")
-        assert (lm.mask(None) == lm._mask_function(None)).all()
+        assert (lm.mask == lm._mask_function(None)).all()
         assert lm._evaluated
         assert (lm._mask == lm._mask_function(None)).all()
 
@@ -400,15 +400,15 @@ class TestLazyMask:
         m = np.ones(10, dtype=bool)
         lm = LazyMask(mask=m)
         assert lm._evaluated
-        assert (lm.mask(None) == m).all()
+        assert (lm.mask == m).all()
 
     def test_manual_trigger_eval(self, lm):
         """Check that accessing mask triggers evaluation if lazy."""
         assert lm._evaluated is False
         assert not hasattr(lm, "_mask")
-        lm._evaluate(None)
+        lm._evaluate()
         assert lm._evaluated
-        assert (lm.mask(None) == lm._mask_function(None)).all()
+        assert (lm.mask == lm._mask_function(None)).all()
         assert (lm._mask == lm._mask_function(None)).all()
 
     def test_trigger_eval_once_only(self):
@@ -440,12 +440,12 @@ class TestLazyMask:
         lm = LazyMask(mask_function=mf)
         assert lm._evaluated is False
         # trigger a mask evaluation:
-        lm.mask(None)
+        lm.mask
         assert lm._evaluated is True
         assert mf.call_counter == 1
         # we shouldn't be able to trigger or force another mask evaluation:
-        lm.mask(None)
-        lm._evaluate(None)
+        lm.mask
+        lm._evaluate()
         assert mf.call_counter == 1
 
     def test_copy(self, lm):
@@ -456,7 +456,7 @@ class TestLazyMask:
         assert not hasattr(lm_unevaluated_copy, "_mask")
         assert lm_unevaluated_copy._mask_function is lm._mask_function
         # trigger evaluated
-        lm._evaluate(None)
+        lm._evaluate()
         assert lm._evaluated
         # now copy after evaluating
         lm_evaluated_copy = copy(lm)
@@ -479,7 +479,7 @@ class TestLazyMask:
         assert not hasattr(lm_unevaluated_copy, "_mask")
         assert lm_unevaluated_copy._mask_function is lm._mask_function
         # trigger evaluated
-        lm._evaluate(None)
+        lm._evaluate()
         assert lm._evaluated
         # now copy after evaluating
         lm_evaluated_copy = deepcopy(lm)
@@ -501,8 +501,8 @@ class TestLazyMask:
             ValueError, match="Cannot compare when one or more masks are not evaluated."
         ):
             lm == lm2
-        lm._evaluate(None)
-        lm2._evaluate(None)
+        lm._evaluate()
+        lm2._evaluate()
         assert lm == lm2
         lmn = LazyMask(mask=None)
         assert lm != lmn
@@ -514,7 +514,7 @@ class TestLazyMask:
             ValueError, match="Cannot compare when one or more masks are not evaluated."
         ):
             lm == m
-        lm._evaluate(None)
+        lm._evaluate()
         assert lm == m
         assert lm != np.zeros(10, dtype=bool)
 


### PR DESCRIPTION
This PR (re-)streamlines accessing the `mask` attribute of a `LazyMask ` so that it no longer requires an argument and can be a `@property`. It then adds features in `masks.py` to allow lazily combining two `MaskCollection`s via lazy merging of `LazyMask`s, and significantly reduces the number of references to `SWIFTGalaxy` objects that we need to keep around attached to masks. `LazyMask` and `MaskCollection` now mostly don't need to know about `SWIFTGalaxy`, except to retrieve a particle count from the metadata when combining masks, which now just asks for the relevant `SWIFTGalaxy` at the relevant time.

Tests have been fleshed out and confirm that we can now delay evaluating masks (and therefore reading any data needed to evaluate them) indefinitely - only when a data read of the relevant particle type is triggered is the mask actually evaluated. Previously we could trigger reading data to evaluate masks for all types when applying a second mask because the masks could not be combined lazily. The implementation is also such that we don't end up with an insane function stack when we combine masks, just a chain of masks applied to `np.arange(num_part)`.

Closes #79