### PR TITLE
Writer updates

### DIFF
--- a/swiftgalaxy/demo_data.py
+++ b/swiftgalaxy/demo_data.py
@@ -502,7 +502,7 @@ class ToyHF(_HaloCatalogue):
                 scale_factor=_a,
                 scale_exponent=1,
             )
-        swift_mask = swiftsimio.mask(self.snapfile, spatial_only=True)
+        swift_mask = swiftsimio.mask(self.snapfile)
         swift_mask.constrain_spatial(spatial_mask)
         return swift_mask
 

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -671,7 +671,7 @@ class SOAP(_HaloCatalogue):
         """
         sm = mask(self.soap_file)
         if self._multi_galaxy:
-            sm.constrain_indices(self._soap_index)
+            sm.constrain_indices(np.array(self._soap_index, dtype=np.dtype("int")))
         else:
             sm.constrain_index(self._soap_index)
         self._catalogue = SWIFTDataset(self.soap_file, mask=sm)

--- a/swiftgalaxy/halo_catalogues.py
+++ b/swiftgalaxy/halo_catalogues.py
@@ -222,7 +222,7 @@ class _HaloCatalogue(ABC):
         :class:`~swiftsimio.masks.SWIFTMask`
             The spatial mask to select particles in the region of interest.
         """
-        sm = mask(snapshot_filename, spatial_only=True)
+        sm = mask(snapshot_filename)
         # this is only supposed to be called if:
         assert self._user_spatial_offsets is not None
         region = [
@@ -669,7 +669,7 @@ class SOAP(_HaloCatalogue):
         Set up the :class:`~swiftsimio.reader.SWIFTDataset` that will handle the SOAP
         catalogue, including the appropriate mask to select only the rows of interest.
         """
-        sm = mask(self.soap_file, spatial_only=not self._multi_galaxy)
+        sm = mask(self.soap_file)
         if self._multi_galaxy:
             sm.constrain_indices(self._soap_index)
         else:
@@ -778,7 +778,7 @@ class SOAP(_HaloCatalogue):
             The spatial mask to select particles in the region of interest.
         """
         pos, rmax = (self._region_centre, self._region_aperture)
-        sm = mask(snapshot_filename, spatial_only=True)
+        sm = mask(snapshot_filename)
         load_region = cosmo_array([pos - rmax, pos + rmax]).T
         sm.constrain_spatial(load_region)
         return sm
@@ -1673,7 +1673,7 @@ class Caesar(_HaloCatalogue):
             The spatial mask to select particles in the region of interest.
         """
         cat = self._mask_catalogue()
-        sm = mask(snapshot_filename, spatial_only=True)
+        sm = mask(snapshot_filename)
         if "total_rmax" in cat.radii.keys():
             # spatial extent information is present, define the mask
             pos = cosmo_array(
@@ -2235,7 +2235,7 @@ class Standalone(_HaloCatalogue):
             The spatial mask to select particles in the region of interest.
         """
         # if we're here then the user didn't provide a mask, read the whole box
-        sm = mask(snapshot_filename, spatial_only=True)
+        sm = mask(snapshot_filename)
         boxsize = sm.metadata.boxsize
         region = cosmo_array([np.zeros_like(boxsize), boxsize]).T
         sm.constrain_spatial(region)

--- a/swiftgalaxy/iterator.py
+++ b/swiftgalaxy/iterator.py
@@ -503,10 +503,10 @@ class SWIFTGalaxies(object):
         iteration_order
         map
         """
-        region_mask = mask(self.snapshot_filename)
         for region, target_indices in zip(
             self._solution["regions"], self._solution["region_target_indices"]
         ):
+            region_mask = mask(self.snapshot_filename)
             region_mask.constrain_spatial(region)
             self._start_server(region_mask)
             for igalaxy in target_indices:

--- a/swiftgalaxy/masks.py
+++ b/swiftgalaxy/masks.py
@@ -108,7 +108,7 @@ class LazyMask(object):
         else:  # sg._spatial_mask is not None
             # get a count of particles in the spatial mask region
             num_part = np.sum(
-                sg._spatial_mask.get_masked_counts_offsets()[0][mask_type]
+                sg._spatial_mask._get_masked_counts_offsets()[0][mask_type]
             )
         if self._mask_function is not None:
             old_mask_function = self._mask_function  # need reference to the current one

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -610,7 +610,7 @@ class TestLazyMask:
         # expect length // 4 since we did [::2] twice:
         assert (
             combined_lm.mask.size
-            == np.sum(sg._spatial_mask.get_masked_counts_offsets()[0]["gas"]) // 4
+            == np.sum(sg._spatial_mask._get_masked_counts_offsets()[0]["gas"]) // 4
         )
 
 
@@ -669,6 +669,6 @@ class TestMaskCollection:
         # expect length // 4 since we did [::2] twice:
         assert (
             combined_mc.dark_matter.mask.size
-            == np.sum(sg._spatial_mask.get_masked_counts_offsets()[0]["dark_matter"])
+            == np.sum(sg._spatial_mask._get_masked_counts_offsets()[0]["dark_matter"])
             // 4
         )


### PR DESCRIPTION
Following the release of some changes in `swiftsimio`, some updates are needed in `swiftgalaxy`. A function got renamed, an inconsistent return type in a `numba` function can be worked around, and repeated masking with `constrain_spatial` to overwrite an old mask is no longer allowed.