### PR TITLE
Only run mypy once in CI

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -37,10 +37,8 @@ jobs:
         run: sphinx-lint --max-line-length 90 -e all docs/source/
       - name: Install mypy
         run: pip install mypy
-      - name: Install types
-        run: mypy --install-types --non-interactive
       - name: Run mypy
-        run: mypy
+        run: mypy --install-types --non-interactive
 
   tests:
     needs: lint


### PR DESCRIPTION
`--install-types` installs the types AND runs mypy.